### PR TITLE
[BEX-346] add bex.internal.bill_fulfilled topic and producer and consumer in prod

### DIFF
--- a/prod-aws/kafka-shared/customer-billing.tf
+++ b/prod-aws/kafka-shared/customer-billing.tf
@@ -1,0 +1,30 @@
+resource "kafka_topic" "invoice_fulfillment" {
+  name               = "bex.internal.bill_fulfilled"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    # keep data for 7 days
+    "retention.ms" = "604800000"
+    # allow max 1 MB for a message
+    "max.message.bytes" = "1048576"
+    "compression.type" = "zstd"
+    "cleanup.policy"   = "delete"
+  }
+}
+
+module "invoice_fulfillment_producer" {
+  source = "../../modules/producer"
+
+  topic = kafka_topic.invoice_fulfillment.name
+
+  cert_common_name = "customer-billing/invoice-fulfillment"
+}
+
+module "bills_total_api_consumer" {
+  source = "../../modules/consumer"
+
+  topic = kafka_topic.invoice_fulfillment.name
+  consumer_group = "bills-total-api-reader"
+
+  cert_common_name = "customer-billing/bills-total-api" 
+}


### PR DESCRIPTION
Create the `bex.internal.bill_fulfilled` topic in production that will contain a `InvoiceFulfilledEvent` (link)[https://github.com/utilitywarehouse/bex-protos/blob/main/fulfilment/internal-events.proto#L33] in an envelope.

Add a producer&consumer for that topic 