### PR TITLE
[BEX] change consumer group name

### DIFF
--- a/dev-aws/kafka-shared/customer-billing.tf
+++ b/dev-aws/kafka-shared/customer-billing.tf
@@ -24,7 +24,7 @@ module "bills_total_api_consumer" {
   source = "../../modules/consumer"
 
   topic          = kafka_topic.invoice_fulfillment.name
-  consumer_group = "bills-total-api-reader"
+  consumer_group = "bex.bills-total-api-reader"
 
   cert_common_name = "customer-billing/bills-total-api"
 }

--- a/prod-aws/kafka-shared/customer-billing.tf
+++ b/prod-aws/kafka-shared/customer-billing.tf
@@ -24,7 +24,7 @@ module "bills_total_api_consumer" {
   source = "../../modules/consumer"
 
   topic = kafka_topic.invoice_fulfillment.name
-  consumer_group = "bills-total-api-reader"
+  consumer_group = "bex.bills-total-api-reader"
 
   cert_common_name = "customer-billing/bills-total-api" 
 }


### PR DESCRIPTION
This is an attempt to rename the consumer group. The `bex.` prefix in the consumer group can be used for permissions based on regexes (see https://utilitywarehouse.slack.com/archives/C0536L8V7EU/p1700065295553729?thread_ts=1700058548.486999&cid=C0536L8V7EU)