### PR TITLE
[BEX-481] fix resource name

### DIFF
--- a/dev-aws/customer-billing/topics.tf
+++ b/dev-aws/customer-billing/topics.tf
@@ -404,7 +404,7 @@ resource "kafka_topic" "deadletter-billing-comms-preferences-events" {
   }
 }
 
-resource "kafka_topic" "account-payment-details.v1" {
+resource "kafka_topic" "account-payment-details_v1" {
   name               = "account-payment-details.v1"
   replication_factor = 3
   partitions         = 10


### PR DESCRIPTION
The topics didn't appear and I wasn't sure how I could check that the files are okay. Running `terraform validate` locally returned this:
```
│ Error: Invalid resource name
│
│   on topics.tf line 407, in resource "kafka_topic" "account-payment-details.v1":
│  407: resource "kafka_topic" "account-payment-details.v1" {
│
│ A name must start with a letter or underscore and may contain only letters, digits, underscores, and dashes.
```

This PR fixes the problem