### PR TITLE
[BEX-482] add production setup for kafka topics for customer-billing

### DIFF
--- a/prod-aws/customer-billing/backend.tf
+++ b/prod-aws/customer-billing/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/prod-aws/customer-billing/provider.tf
+++ b/prod-aws/customer-billing/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    kafka = {
+      source = "Mongey/kafka"
+    }
+  }
+}
+
+provider "kafka" {
+  bootstrap_servers = [
+    "kafka-bitnami-0.kafka-bitnami-headless.customer-billing.svc.cluster.aws:9092",
+    "kafka-bitnami-1.kafka-bitnami-headless.customer-billing.svc.cluster.aws:9092",
+    "kafka-bitnami-2.kafka-bitnami-headless.customer-billing.svc.cluster.aws:9092",
+  ]
+  tls_enabled = false
+}

--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -1,0 +1,405 @@
+resource "kafka_topic" "finance-invoice-model" {
+  name               = "finance-invoice-model"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "invoice-fulfilment-event" {
+  name               = "invoice-fulfilment-event"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "invoice-delivery-events" {
+  name               = "invoice-delivery-events"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "email-delivery-engine-send-failures" {
+  name               = "email-delivery-engine-send-failures"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "invoice-fulfilment-event-deadletter" {
+  name               = "invoice-fulfilment-event-deadletter"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "invoice-redelivery-rejections" {
+  name               = "invoice-redelivery-rejections"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "invoice-diffs" {
+  name               = "invoice-diffs"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "public-fulfilment-events" {
+  name               = "public-fulfilment-events"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    "retention.bytes"  = "-1"
+    "retention.ms"     = "-1"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "dummy-bill-extracts-historic-model" {
+  name               = "dummy-bill-extracts-historic-model"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "dummy-bill-core-model" {
+  name               = "dummy-bill-core-model"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "replicated-billing-engine-events" {
+  name               = "replicated-billing-engine-events"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    "retention.bytes"  = "-1"
+    "retention.ms"     = "-1"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "replicated-internal-bill-core-model" {
+  name               = "replicated-internal-bill-core-model"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "replicated-bill-core-model" {
+  name               = "replicated-bill-core-model"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    "retention.bytes"  = "-1"
+    "retention.ms"     = "-1"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "replicated-bill-extracts-historic-model" {
+  name               = "replicated-bill-extracts-historic-model"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "budget-plan" {
+  name               = "budget-plan"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "customer-change" {
+  name               = "customer-change"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "eqdb-loader" {
+  name               = "eqdb-loader"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "legacy-data-deadletter" {
+  name               = "legacy-data-deadletter"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "legacy-accounts-deadletter" {
+  name               = "legacy-accounts-deadletter"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "account-balance-change-deadletter" {
+  name               = "account-balance-change-deadletter"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "budget-plan-calculation-deadletter" {
+  name               = "budget-plan-calculation-deadletter"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "budget-plan-fabrication-deadletter" {
+  name               = "budget-plan-fabrication-deadletter"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "budget-plan-change-notification-failures" {
+  name               = "budget-plan-change-notification-failures"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "budget-plan-change-notification-deliveries" {
+  name               = "budget-plan-change-notification-deliveries"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "bill-budget-plan-proximo-reader-deadletter" {
+  name               = "bill-budget-plan-proximo-reader-deadletter"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "billing-comms-preferences-events" {
+  name               = "billing-comms-preferences-events"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "deadletter-billing-comms-preferences-events" {
+  name               = "deadletter-billing-comms-preferences-events"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "account-payment-details_v1" {
+  name               = "account-payment-details.v1"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "dummy-placeholder" {
+  name               = "dummy-placeholder"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}


### PR DESCRIPTION
Create the topics that we currently have on the old kafka cluster in the new kafka cluster based on this list: https://github.com/utilitywarehouse/kubernetes-manifests/blob/master/prod-aws/customer-billing/kafka-topic-applier/topics.yaml

Configuration is changed because the configured values are too high, we applied the same changes we did in dev