### PR TITLE
Migrate IAM cerbos audit to kafka module(s)

### DIFF
--- a/dev-aws/kafka-shared/iam_cerbos-audit.tf
+++ b/dev-aws/kafka-shared/iam_cerbos-audit.tf
@@ -14,6 +14,37 @@ resource "kafka_topic" "iam_cerbos_audit_v1" {
   }
 }
 
+module "iam_cerbos_audit_producer" {
+  source = "../../modules/producer"
+
+  topic = kafka_topic.iam_cerbos_audit_v1.name
+
+  cert_common_name = "auth/iam-policy-decision-api"
+}
+
+module "iam_cerbos_audit_indexer_consumer" {
+  source = "../../modules/consumer"
+
+  topic          = kafka_topic.iam_identitydb_v1.name
+  consumer_group = "iam-cerbos-audit-indexer"
+
+  cert_common_name = "auth/iam-cerbos-audit-v1-indexer"
+}
+
+module "iam_cerbos_audit_exporter_consumer" {
+  source = "../../modules/consumer"
+
+  topic          = kafka_topic.iam_identitydb_v1.name
+  consumer_group = "iam-cerbos-audit-exporter"
+
+  cert_common_name = "auth/iam-cerbos-audit-v1-exporter"
+}
+
+###
+## ---- OLD ----
+## Remove the below once clients have migrated to the above
+###
+
 resource "kafka_acl" "iam_cerbos_audit_v1_access" {
   resource_name       = "auth.iam-cerbos-audit-v1"
   resource_type       = "Topic"

--- a/dev-aws/kafka-shared/iam_identitydb.tf
+++ b/dev-aws/kafka-shared/iam_identitydb.tf
@@ -27,7 +27,7 @@ module "iam_identitydb_snapshotter_consumer" {
   source = "../../modules/consumer"
 
   topic          = kafka_topic.iam_identitydb_v1.name
-  consumer_group = "iam-identitydb-snapshotter-v1"
+  consumer_group = "iam-identitydb-snapshotter"
 
   cert_common_name = "auth/iam-identitydb-snapshotter"
 }
@@ -36,7 +36,7 @@ module "iam_identitydb_identity_api_consumer" {
   source = "../../modules/consumer"
 
   topic          = kafka_topic.iam_identitydb_v1.name
-  consumer_group = "iam-identity-api-v1"
+  consumer_group = "iam-identity-api"
 
   cert_common_name = "auth/iam-identity-api"
 }
@@ -45,7 +45,7 @@ module "iam_identitydb_policy_decision_api_consumer" {
   source = "../../modules/consumer"
 
   topic          = kafka_topic.iam_identitydb_v1.name
-  consumer_group = "iam-policy-decision-api-v1"
+  consumer_group = "iam-policy-decision-api"
 
   cert_common_name = "auth/iam-policy-decision-api"
 }

--- a/prod-aws/kafka-shared/iam_cerbos-audit.tf
+++ b/prod-aws/kafka-shared/iam_cerbos-audit.tf
@@ -14,6 +14,37 @@ resource "kafka_topic" "iam_cerbos_audit_v1" {
   }
 }
 
+module "iam_cerbos_audit_producer" {
+  source = "../../modules/producer"
+
+  topic = kafka_topic.iam_cerbos_audit_v1.name
+
+  cert_common_name = "auth/iam-policy-decision-api"
+}
+
+module "iam_cerbos_audit_indexer_consumer" {
+  source = "../../modules/consumer"
+
+  topic          = kafka_topic.iam_identitydb_v1.name
+  consumer_group = "iam-cerbos-audit-indexer"
+
+  cert_common_name = "auth/iam-cerbos-audit-v1-indexer"
+}
+
+module "iam_cerbos_audit_exporter_consumer" {
+  source = "../../modules/consumer"
+
+  topic          = kafka_topic.iam_identitydb_v1.name
+  consumer_group = "iam-cerbos-audit-exporter"
+
+  cert_common_name = "auth/iam-cerbos-audit-v1-exporter"
+}
+
+###
+## ---- OLD ----
+## Remove the below once clients have migrated to the above
+###
+
 resource "kafka_acl" "iam_cerbos_audit_v1_access" {
   resource_name       = "auth.iam-cerbos-audit-v1"
   resource_type       = "Topic"


### PR DESCRIPTION
Use provided modules to cleanup defining producers and consumers. Naming has tweaked intentionally; once clients have migrated will raise a PR to remvoe the old definitions.