### PR TITLE
DENA-437: new module for app definition includes both consumers & producers

### DIFF
--- a/dev-aws/kafka-shared/iam_cerbos-audit.tf
+++ b/dev-aws/kafka-shared/iam_cerbos-audit.tf
@@ -14,14 +14,6 @@ resource "kafka_topic" "iam_cerbos_audit_v1" {
   }
 }
 
-module "iam_cerbos_audit_producer" {
-  source = "../../modules/producer"
-
-  topic = kafka_topic.iam_cerbos_audit_v1.name
-
-  cert_common_name = "auth/iam-policy-decision-api"
-}
-
 module "iam_cerbos_audit_indexer_consumer" {
   source = "../../modules/consumer"
 

--- a/dev-aws/kafka-shared/iam_identitydb.tf
+++ b/dev-aws/kafka-shared/iam_identitydb.tf
@@ -42,8 +42,6 @@ module "iam_identitydb_identity_api_consumer" {
 }
 
 module "iam_policy_decision_api" {
-  depends_on = [kafka_topic.iam_identitydb_v1, kafka_topic.iam_cerbos_audit_v1]
-
   source = "../../modules/tls-app"
 
   cert_common_name = "auth/iam-policy-decision-api"

--- a/dev-aws/kafka-shared/iam_identitydb.tf
+++ b/dev-aws/kafka-shared/iam_identitydb.tf
@@ -41,11 +41,13 @@ module "iam_identitydb_identity_api_consumer" {
   cert_common_name = "auth/iam-identity-api"
 }
 
-module "iam_identitydb_policy_decision_api_consumer" {
-  source = "../../modules/consumer"
+module "iam_policy_decision_api" {
+  depends_on = [kafka_topic.iam_identitydb_v1, kafka_topic.iam_cerbos_audit_v1]
 
-  topic          = kafka_topic.iam_identitydb_v1.name
-  consumer_group = "iam-policy-decision-api"
+  source = "../../modules/tls-app"
 
   cert_common_name = "auth/iam-policy-decision-api"
+
+  produce_topics = [kafka_topic.iam_cerbos_audit_v1.name]
+  consume_topics = { (kafka_topic.iam_identitydb_v1.name) : "iam-policy-decision-api" }
 }

--- a/modules/tls-app/main.tf
+++ b/modules/tls-app/main.tf
@@ -1,0 +1,42 @@
+# Consumers
+resource "kafka_acl" "topic_acl" {
+  for_each            = var.consume_topics
+  resource_name       = each.key
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=${var.cert_common_name}"
+  acl_host            = var.acl_host
+  acl_operation       = "Read"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "group_acl" {
+  for_each            = var.consume_topics
+  resource_name       = each.value
+  resource_type       = "Group"
+  acl_principal       = "User:CN=${var.cert_common_name}"
+  acl_host            = var.acl_host
+  acl_operation       = "Read"
+  acl_permission_type = "Allow"
+}
+
+# Producers
+resource "kafka_acl" "producer_acl" {
+  for_each            = toset(var.produce_topics)
+  resource_name       = each.key
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=${var.cert_common_name}"
+  acl_host            = var.acl_host
+  acl_operation       = "Write"
+  acl_permission_type = "Allow"
+}
+
+# Quota
+resource "kafka_quota" "producer_quota" {
+  entity_name = "User:CN=${var.cert_common_name}"
+  entity_type = "user"
+  config      = {
+    "consumer_byte_rate" = tostring(var.consumer_byte_rate)
+    "producer_byte_rate" = tostring(var.producer_byte_rate)
+    "request_percentage" = tostring(var.request_percentage)
+  }
+}

--- a/modules/tls-app/provider.tf
+++ b/modules/tls-app/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    kafka = {
+      source = "Mongey/kafka"
+    }
+  }
+}

--- a/modules/tls-app/variables.tf
+++ b/modules/tls-app/variables.tf
@@ -1,0 +1,58 @@
+variable "produce_topics" {
+  type        = list(string)
+  description = "The topics that the app produces to"
+  default     = []
+}
+
+variable "consume_topics" {
+  type        = map(string)
+  description = "The topics that the app consumes. Map containing as keys the topic names and as values the consumer group name for that topic."
+  default     = {}
+}
+
+variable "cert_common_name" {
+  type        = string
+  description = "The principal or user/group for which the ACL is being created."
+}
+
+# ACL
+variable "acl_host" {
+  type        = string
+  description = "The host from which the principal is allowed to perform operations. Set to '*' to allow any host."
+  default     = "*"
+}
+
+# QUOTA
+variable "consumer_byte_rate" {
+  type        = number
+  description = "The maximum number of bytes per second a producer is allowed to produce to the specified entity."
+  default     = 5242880 # Limit producing to 5 MB/s
+
+  validation {
+    condition     = var.consumer_byte_rate > 0 && var.consumer_byte_rate <= 10485760
+    error_message = "Producer byte rate must be between 0 bytes per second and 10 MB per second (inclusive)."
+  }
+}
+
+variable "producer_byte_rate" {
+  type        = number
+  description = "The maximum number of bytes per second a producer is allowed to produce to the specified entity."
+  default     = 5242880 # Limit producing to 5 MB/s
+
+  validation {
+    condition     = var.producer_byte_rate > 0 && var.producer_byte_rate <= 10485760
+    error_message = "Producer byte rate must be between 0 bytes per second and 10 MB per second (inclusive)."
+  }
+}
+
+variable "request_percentage" {
+  type        = number
+  description = "The percentage of requests a specified entity is allowed to make."
+  # Allow 100% of CPU. More on this here: https://docs.confluent.io/kafka/design/quotas.html#request-rate-quotas
+  default     = 100
+
+  validation {
+    condition     = var.request_percentage >= 0 && var.request_percentage <= 100
+    error_message = "Request percentage must be between 0 and 100 (inclusive)."
+  }
+}


### PR DESCRIPTION
- introduce new module for an app that defines both consumers & producers and a single quota.
- fixes the quota for iam-policy-decision-api which was defined twice before: once by the consumer module & once by the producer

This comes from the need of having a single quota / user (in our case per certificate) and I think it would be also simpler for devs to define like this.

If this is fine, I'll migrate all the consumers/producers to the new module, and remove the consumer & producer modules afterwards. 

The plan in de-aws is:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  - destroy

Terraform will perform the following actions:

  # module.iam_cerbos_audit_producer.kafka_acl.producer_acl will be destroyed
  # (because kafka_acl.producer_acl is not in configuration)
  - resource "kafka_acl" "producer_acl" {
      - acl_host                     = "*" -> null
      - acl_operation                = "Write" -> null
      - acl_permission_type          = "Allow" -> null
      - acl_principal                = "User:CN=auth/iam-policy-decision-api" -> null
      - id                           = "User:CN=auth/iam-policy-decision-api|*|Write|Allow|Topic|auth.iam-cerbos-audit-v1|Literal" -> null
      - resource_name                = "auth.iam-cerbos-audit-v1" -> null
      - resource_pattern_type_filter = "Literal" -> null
      - resource_type                = "Topic" -> null
    }

  # module.iam_cerbos_audit_producer.kafka_quota.producer_quota will be destroyed
  # (because kafka_quota.producer_quota is not in configuration)
  - resource "kafka_quota" "producer_quota" {
      - config      = {
          - "consumer_byte_rate" = 5242880
          - "producer_byte_rate" = 5242880
          - "request_percentage" = 100
        } -> null
      - entity_name = "User:CN=auth/iam-policy-decision-api" -> null
      - entity_type = "user" -> null
      - id          = "User:CN=auth/iam-policy-decision-api|user" -> null
    }

  # module.iam_identitydb_policy_decision_api_consumer.kafka_acl.group_acl will be destroyed
  # (because kafka_acl.group_acl is not in configuration)
  - resource "kafka_acl" "group_acl" {
      - acl_host                     = "*" -> null
      - acl_operation                = "Read" -> null
      - acl_permission_type          = "Allow" -> null
      - acl_principal                = "User:CN=auth/iam-policy-decision-api" -> null
      - id                           = "User:CN=auth/iam-policy-decision-api|*|Read|Allow|Group|iam-policy-decision-api|Literal" -> null
      - resource_name                = "iam-policy-decision-api" -> null
      - resource_pattern_type_filter = "Literal" -> null
      - resource_type                = "Group" -> null
    }

  # module.iam_identitydb_policy_decision_api_consumer.kafka_acl.topic_acl will be destroyed
  # (because kafka_acl.topic_acl is not in configuration)
  - resource "kafka_acl" "topic_acl" {
      - acl_host                     = "*" -> null
      - acl_operation                = "Read" -> null
      - acl_permission_type          = "Allow" -> null
      - acl_principal                = "User:CN=auth/iam-policy-decision-api" -> null
      - id                           = "User:CN=auth/iam-policy-decision-api|*|Read|Allow|Topic|auth.iam-identitydb-v1|Literal" -> null
      - resource_name                = "auth.iam-identitydb-v1" -> null
      - resource_pattern_type_filter = "Literal" -> null
      - resource_type                = "Topic" -> null
    }

  # module.iam_identitydb_policy_decision_api_consumer.kafka_quota.consumer_quota will be destroyed
  # (because kafka_quota.consumer_quota is not in configuration)
  - resource "kafka_quota" "consumer_quota" {
      - config      = {
          - "consumer_byte_rate" = 5242880
          - "producer_byte_rate" = 5242880
          - "request_percentage" = 100
        } -> null
      - entity_name = "User:CN=auth/iam-policy-decision-api" -> null
      - entity_type = "user" -> null
      - id          = "User:CN=auth/iam-policy-decision-api|user" -> null
    }

  # module.iam_policy_decision_api.kafka_acl.group_acl["auth.iam-identitydb-v1"] will be created
  + resource "kafka_acl" "group_acl" {
      + acl_host                     = "*"
      + acl_operation                = "Read"
      + acl_permission_type          = "Allow"
      + acl_principal                = "User:CN=auth/iam-policy-decision-api"
      + id                           = (known after apply)
      + resource_name                = "iam-policy-decision-api"
      + resource_pattern_type_filter = "Literal"
      + resource_type                = "Group"
    }

  # module.iam_policy_decision_api.kafka_acl.producer_acl["auth.iam-cerbos-audit-v1"] will be created
  + resource "kafka_acl" "producer_acl" {
      + acl_host                     = "*"
      + acl_operation                = "Write"
      + acl_permission_type          = "Allow"
      + acl_principal                = "User:CN=auth/iam-policy-decision-api"
      + id                           = (known after apply)
      + resource_name                = "auth.iam-cerbos-audit-v1"
      + resource_pattern_type_filter = "Literal"
      + resource_type                = "Topic"
    }

  # module.iam_policy_decision_api.kafka_acl.topic_acl["auth.iam-identitydb-v1"] will be created
  + resource "kafka_acl" "topic_acl" {
      + acl_host                     = "*"
      + acl_operation                = "Read"
      + acl_permission_type          = "Allow"
      + acl_principal                = "User:CN=auth/iam-policy-decision-api"
      + id                           = (known after apply)
      + resource_name                = "auth.iam-identitydb-v1"
      + resource_pattern_type_filter = "Literal"
      + resource_type                = "Topic"
    }

  # module.iam_policy_decision_api.kafka_quota.producer_quota will be created
  + resource "kafka_quota" "producer_quota" {
      + config      = {
          + "consumer_byte_rate" = 5242880
          + "producer_byte_rate" = 5242880
          + "request_percentage" = 100
        }
      + entity_name = "User:CN=auth/iam-policy-decision-api"
      + entity_type = "user"
      + id          = (known after apply)
    }

Plan: 4 to add, 0 to change, 5 to destroy.
╷
│ Warning: Argument is deprecated
│
│   with provider["registry.terraform.io/mongey/kafka"],
│   on provider.tf line 9, in provider "kafka":
│    9: provider "kafka" {
│
│ This parameter is now deprecated and will be removed in a later release, please use `client_key` instead.
│
│ (and 5 more similar warnings elsewhere)
```