### PR TITLE
DENA-437: shared kafka config: port app definition to prod

### DIFF
--- a/prod-aws/kafka-shared/iam_cerbos-audit.tf
+++ b/prod-aws/kafka-shared/iam_cerbos-audit.tf
@@ -14,14 +14,6 @@ resource "kafka_topic" "iam_cerbos_audit_v1" {
   }
 }
 
-module "iam_cerbos_audit_producer" {
-  source = "../../modules/producer"
-
-  topic = kafka_topic.iam_cerbos_audit_v1.name
-
-  cert_common_name = "auth/iam-policy-decision-api"
-}
-
 module "iam_cerbos_audit_indexer_consumer" {
   source = "../../modules/consumer"
 

--- a/prod-aws/kafka-shared/iam_identitydb.tf
+++ b/prod-aws/kafka-shared/iam_identitydb.tf
@@ -41,11 +41,11 @@ module "iam_identitydb_identity_api_consumer" {
   cert_common_name = "auth/iam-identity-api"
 }
 
-module "iam_identitydb_policy_decision_api_consumer" {
-  source = "../../modules/consumer"
-
-  topic          = kafka_topic.iam_identitydb_v1.name
-  consumer_group = "iam-policy-decision-api"
+module "iam_policy_decision_api" {
+  source = "../../modules/tls-app"
 
   cert_common_name = "auth/iam-policy-decision-api"
+
+  produce_topics = [kafka_topic.iam_cerbos_audit_v1.name]
+  consume_topics = { (kafka_topic.iam_identitydb_v1.name) : "iam-policy-decision-api" }
 }


### PR DESCRIPTION
This will fix the quota for iam-policy-decision-api.

Related to the dev pr: https://github.com/utilitywarehouse/kafka-cluster-config/pull/117