### PR TITLE
kafka-shared: renamed the quota in the tls-app

### DIFF
--- a/dev-aws/kafka-shared/iam_identitydb.tf
+++ b/dev-aws/kafka-shared/iam_identitydb.tf
@@ -49,3 +49,8 @@ module "iam_policy_decision_api" {
   produce_topics = [kafka_topic.iam_cerbos_audit_v1.name]
   consume_topics = { (kafka_topic.iam_identitydb_v1.name) : "iam-policy-decision-api" }
 }
+
+moved {
+  from = module.iam_policy_decision_api.kafka_quota.producer_quota
+  to   = module.iam_policy_decision_api.kafka_quota.quota
+}

--- a/modules/tls-app/main.tf
+++ b/modules/tls-app/main.tf
@@ -31,7 +31,7 @@ resource "kafka_acl" "producer_acl" {
 }
 
 # Quota
-resource "kafka_quota" "producer_quota" {
+resource "kafka_quota" "quota" {
   entity_name = "User:CN=${var.cert_common_name}"
   entity_type = "user"
   config      = {

--- a/prod-aws/kafka-shared/iam_identitydb.tf
+++ b/prod-aws/kafka-shared/iam_identitydb.tf
@@ -49,3 +49,8 @@ module "iam_policy_decision_api" {
   produce_topics = [kafka_topic.iam_cerbos_audit_v1.name]
   consume_topics = { (kafka_topic.iam_identitydb_v1.name) : "iam-policy-decision-api" }
 }
+
+moved {
+  from = module.iam_policy_decision_api.kafka_quota.producer_quota
+  to   = module.iam_policy_decision_api.kafka_quota.quota
+}


### PR DESCRIPTION
Renaming from producer_quota to just quota, as it contains also consuming rate and it is one per app.

The move blocks will make sure the resource is not destroyed, but it is kept upon applying.

The plan for dev is:
```
Terraform will perform the following actions:

  # module.iam_policy_decision_api.kafka_quota.producer_quota has moved to module.iam_policy_decision_api.kafka_quota.quota
    resource "kafka_quota" "quota" {
        id          = "User:CN=auth/iam-policy-decision-api|user"
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.
╷
│ Warning: Argument is deprecated
│
│   with provider["registry.terraform.io/mongey/kafka"],
│   on provider.tf line 9, in provider "kafka":
│    9: provider "kafka" {
│
│ This parameter is now deprecated and will be removed in a later release, please use `ca_cert` instead.
│
│ (and 5 more similar warnings elsewhere)
```