### PR TITLE
DENA-437: kafka-shared: dev: refactor customer billing to use the new tls-app module

### DIFF
--- a/dev-aws/kafka-shared/customer-billing.tf
+++ b/dev-aws/kafka-shared/customer-billing.tf
@@ -27,16 +27,43 @@ resource "kafka_topic" "invoice_fulfillment_deadletter" {
 }
 
 module "invoice_fulfillment" {
-  source = "../../modules/tls-app"
-
+  source           = "../../modules/tls-app"
   cert_common_name = "customer-billing/invoice-fulfillment"
   produce_topics   = [kafka_topic.invoice_fulfillment.name, kafka_topic.invoice_fulfillment_deadletter.name]
 }
 
 module "bills_total_api" {
-  source = "../../modules/tls-app"
-
+  source           = "../../modules/tls-app"
   cert_common_name = "customer-billing/bills-total-api"
   consume_topics   = { (kafka_topic.invoice_fulfillment.name) : "bex.bills-total-api-reader" }
 }
 
+moved {
+  from = module.invoice_fulfillment_deadletter_producer.kafka_acl.producer_acl
+  to   = module.invoice_fulfillment.kafka_acl.producer_acl["bex.internal.accountreadytobefulfilled_deadletter"]
+}
+
+moved {
+  from = module.invoice_fulfillment_producer.kafka_acl.producer_acl
+  to   = module.invoice_fulfillment.kafka_acl.producer_acl["bex.internal.bill_fulfilled"]
+}
+
+moved {
+  from = module.invoice_fulfillment_producer.kafka_quota.producer_quota
+  to   = module.invoice_fulfillment.kafka_quota.quota
+}
+
+moved {
+  from = module.bills_total_api_consumer.kafka_acl.topic_acl
+  to   = module.bills_total_api.kafka_acl.topic_acl["bex.internal.bill_fulfilled"]
+}
+
+moved {
+  from = module.bills_total_api_consumer.kafka_acl.group_acl
+  to   = module.bills_total_api.kafka_acl.group_acl["bex.internal.bill_fulfilled"]
+}
+
+moved {
+  from = module.bills_total_api_consumer.kafka_quota.consumer_quota
+  to   = module.bills_total_api.kafka_quota.quota
+}

--- a/dev-aws/kafka-shared/customer-billing.tf
+++ b/dev-aws/kafka-shared/customer-billing.tf
@@ -2,40 +2,23 @@ resource "kafka_topic" "invoice_fulfillment" {
   name               = "bex.internal.bill_fulfilled"
   replication_factor = 3
   partitions         = 10
-  config = {
+  config             = {
     # keep data for 7 days
-    "retention.ms" = "604800000"
+    "retention.ms"      = "604800000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }
-}
-
-module "invoice_fulfillment_producer" {
-  source = "../../modules/producer"
-
-  topic = kafka_topic.invoice_fulfillment.name
-
-  cert_common_name = "customer-billing/invoice-fulfillment"
-}
-
-module "bills_total_api_consumer" {
-  source = "../../modules/consumer"
-
-  topic          = kafka_topic.invoice_fulfillment.name
-  consumer_group = "bex.bills-total-api-reader"
-
-  cert_common_name = "customer-billing/bills-total-api"
 }
 
 resource "kafka_topic" "invoice_fulfillment_deadletter" {
   name               = "bex.internal.accountreadytobefulfilled_deadletter"
   replication_factor = 3
   partitions         = 10
-  config = {
+  config             = {
     # keep data for 14 days
-    "retention.ms" = "1209600000"
+    "retention.ms"      = "1209600000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"
@@ -43,10 +26,17 @@ resource "kafka_topic" "invoice_fulfillment_deadletter" {
   }
 }
 
-module "invoice_fulfillment_deadletter_producer" {
-  source = "../../modules/producer"
-
-  topic = kafka_topic.invoice_fulfillment_deadletter.name
+module "invoice_fulfillment" {
+  source = "../../modules/tls-app"
 
   cert_common_name = "customer-billing/invoice-fulfillment"
+  produce_topics   = [kafka_topic.invoice_fulfillment.name, kafka_topic.invoice_fulfillment_deadletter.name]
 }
+
+module "bills_total_api" {
+  source = "../../modules/tls-app"
+
+  cert_common_name = "customer-billing/bills-total-api"
+  consume_topics   = { (kafka_topic.invoice_fulfillment.name) : "bex.bills-total-api-reader" }
+}
+


### PR DESCRIPTION
Some of the moved items need to be replaced, so this means destroy + add, so there will be a little bit of disruption.

The plan is:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.bills_total_api_consumer.kafka_acl.group_acl has moved to module.bills_total_api.kafka_acl.group_acl["bex.internal.bill_fulfilled"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=customer-billing/bills-total-api|*|Read|Allow|Group|bex.bills-total-api-reader|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.bills_total_api_consumer.kafka_acl.topic_acl has moved to module.bills_total_api.kafka_acl.topic_acl["bex.internal.bill_fulfilled"]
    resource "kafka_acl" "topic_acl" {
        id                           = "User:CN=customer-billing/bills-total-api|*|Read|Allow|Topic|bex.internal.bill_fulfilled|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.bills_total_api.kafka_quota.quota must be replaced
  # (moved from module.bills_total_api_consumer.kafka_quota.consumer_quota)
-/+ resource "kafka_quota" "quota" {
      ~ config      = { # forces replacement
          + "producer_byte_rate" = 5242880
            # (2 unchanged elements hidden)
        }
      ~ id          = "User:CN=customer-billing/bills-total-api|user" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # module.invoice_fulfillment_deadletter_producer.kafka_acl.producer_acl has moved to module.invoice_fulfillment.kafka_acl.producer_acl["bex.internal.accountreadytobefulfilled_deadletter"]
    resource "kafka_acl" "producer_acl" {
        id                           = "User:CN=customer-billing/invoice-fulfillment|*|Write|Allow|Topic|bex.internal.accountreadytobefulfilled_deadletter|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.invoice_fulfillment_producer.kafka_acl.producer_acl has moved to module.invoice_fulfillment.kafka_acl.producer_acl["bex.internal.bill_fulfilled"]
    resource "kafka_acl" "producer_acl" {
        id                           = "User:CN=customer-billing/invoice-fulfillment|*|Write|Allow|Topic|bex.internal.bill_fulfilled|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.invoice_fulfillment.kafka_quota.quota must be replaced
  # (moved from module.invoice_fulfillment_producer.kafka_quota.producer_quota)
-/+ resource "kafka_quota" "quota" {
      ~ config      = { # forces replacement
          + "consumer_byte_rate" = 5242880
            # (2 unchanged elements hidden)
        }
      ~ id          = "User:CN=customer-billing/invoice-fulfillment|user" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # module.invoice_fulfillment_deadletter_producer.kafka_quota.producer_quota will be destroyed
  # (because kafka_quota.producer_quota is not in configuration)
  - resource "kafka_quota" "producer_quota" {
      - config      = {
          - "producer_byte_rate" = 5242880
          - "request_percentage" = 100
        } -> null
      - entity_name = "User:CN=customer-billing/invoice-fulfillment" -> null
      - entity_type = "user" -> null
      - id          = "User:CN=customer-billing/invoice-fulfillment|user" -> null
    }

Plan: 2 to add, 0 to change, 3 to destroy.
╷
│ Warning: Argument is deprecated
│
│   with provider["registry.terraform.io/mongey/kafka"],
│   on provider.tf line 9, in provider "kafka":
│    9: provider "kafka" {
│
│ This parameter is now deprecated and will be removed in a later release, please use `client_key` instead.
│
│ (and 5 more similar warnings elsewhere)
╵
```
