### PR TITLE
DENA-437: kafka-shared: dev: refactor iam to use the tls-app module

### DIFF
--- a/dev-aws/kafka-shared/iam_credentials.tf
+++ b/dev-aws/kafka-shared/iam_credentials.tf
@@ -2,11 +2,11 @@ resource "kafka_topic" "iam_credentials_v1" {
   name               = "auth-customer.iam-credentials-v1"
   replication_factor = 3
   partitions         = 10
-  config = {
+  config             = {
     # retain 100MB on each partition
-    "retention.bytes" = "104857600"
+    "retention.bytes"   = "104857600"
     # keep data for 7 days
-    "retention.ms" = "604800000"
+    "retention.ms"      = "604800000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"
@@ -14,27 +14,55 @@ resource "kafka_topic" "iam_credentials_v1" {
   }
 }
 
-module "iam_credentials_producer_api" {
-  source = "../../modules/producer"
-
-  topic = kafka_topic.iam_credentials_v1.name
-
+module "iam_credentials_api" {
+  source           = "../../modules/tls-app"
+  produce_topics   = [kafka_topic.iam_credentials_v1.name]
   cert_common_name = "auth-customer/credentials-api"
 }
 
-module "iam_credentials_producer_auth_provider" {
-  source = "../../modules/producer"
-
-  topic = kafka_topic.iam_credentials_v1.name
-
+module "iam_clubhouse_auth_provider" {
+  source           = "../../modules/tls-app"
+  produce_topics   = [kafka_topic.iam_credentials_v1.name]
   cert_common_name = "clubhouse/auth-provider"
 }
 
-module "iam_credentials_consumer" {
-  source = "../../modules/consumer"
-
-  topic          = kafka_topic.iam_credentials_v1.name
-  consumer_group = "indexer-iam-credentials-v1"
-
+module "iam_credentials_indexer" {
+  source           = "../../modules/tls-app"
+  consume_topics   = { (kafka_topic.iam_credentials_v1.name) : "indexer-iam-credentials-v1" }
   cert_common_name = "auth-customer/iam-credentials-v1-indexer"
+}
+
+moved {
+  from = module.iam_credentials_producer_auth_provider.kafka_acl.producer_acl
+  to   = module.iam_clubhouse_auth_provider.kafka_acl.producer_acl["auth-customer.iam-credentials-v1"]
+}
+
+moved {
+  from = module.iam_credentials_producer_auth_provider.kafka_quota.producer_quota
+  to   = module.iam_clubhouse_auth_provider.kafka_quota.quota
+}
+
+moved {
+  from = module.iam_credentials_producer_api.kafka_acl.producer_acl
+  to   = module.iam_credentials_api.kafka_acl.producer_acl["auth-customer.iam-credentials-v1"]
+}
+
+moved {
+  from = module.iam_credentials_producer_api.kafka_quota.producer_quota
+  to   = module.iam_credentials_api.kafka_quota.quota
+}
+
+moved {
+  from = module.iam_credentials_consumer.kafka_acl.group_acl
+  to   = module.iam_credentials_indexer.kafka_acl.group_acl["auth-customer.iam-credentials-v1"]
+}
+
+moved {
+  from = module.iam_credentials_consumer.kafka_acl.topic_acl
+  to   = module.iam_credentials_indexer.kafka_acl.topic_acl["auth-customer.iam-credentials-v1"]
+}
+
+moved {
+  from = module.iam_credentials_consumer.kafka_quota.consumer_quota
+  to   = module.iam_credentials_indexer.kafka_quota.quota
 }

--- a/dev-aws/kafka-shared/iam_identitydb.tf
+++ b/dev-aws/kafka-shared/iam_identitydb.tf
@@ -3,11 +3,11 @@ resource "kafka_topic" "iam_identitydb_v1" {
   replication_factor = 3
   # MUST be 1 partition as identitydb assumes this to be true
   partitions         = 1
-  config = {
+  config             = {
     # retain 100MB on each partition
-    "retention.bytes" = "104857600"
+    "retention.bytes"   = "104857600"
     # keep data for 30 days
-    "retention.ms" = "2592000000"
+    "retention.ms"      = "2592000000"
     # allow max 5 MB for a message
     "max.message.bytes" = "5242880"
     "compression.type"  = "zstd"
@@ -15,42 +15,72 @@ resource "kafka_topic" "iam_identitydb_v1" {
   }
 }
 
-module "iam_identitydb_event_forwarder_producer" {
-  source = "../../modules/producer"
-
-  topic = kafka_topic.iam_identitydb_v1.name
-
+module "iam_identitydb_event_forwarder" {
+  source           = "../../modules/tls-app"
+  produce_topics   = [kafka_topic.iam_identitydb_v1.name]
   cert_common_name = "auth/iam-identitydb-event-forwarder"
 }
 
-module "iam_identitydb_snapshotter_consumer" {
-  source = "../../modules/consumer"
-
-  topic          = kafka_topic.iam_identitydb_v1.name
-  consumer_group = "iam-identitydb-snapshotter"
-
+module "iam_identitydb_snapshotter" {
+  source           = "../../modules/tls-app"
+  consume_topics   = { (kafka_topic.iam_identitydb_v1.name) : "iam-identitydb-snapshotter" }
   cert_common_name = "auth/iam-identitydb-snapshotter"
 }
 
-module "iam_identitydb_identity_api_consumer" {
-  source = "../../modules/consumer"
-
-  topic          = kafka_topic.iam_identitydb_v1.name
-  consumer_group = "iam-identity-api"
-
+module "iam_identity_api" {
+  source           = "../../modules/tls-app"
+  consume_topics   = { (kafka_topic.iam_identitydb_v1.name) : "iam-identity-api" }
   cert_common_name = "auth/iam-identity-api"
 }
 
 module "iam_policy_decision_api" {
-  source = "../../modules/tls-app"
-
+  source           = "../../modules/tls-app"
   cert_common_name = "auth/iam-policy-decision-api"
-
-  produce_topics = [kafka_topic.iam_cerbos_audit_v1.name]
-  consume_topics = { (kafka_topic.iam_identitydb_v1.name) : "iam-policy-decision-api" }
+  produce_topics   = [kafka_topic.iam_cerbos_audit_v1.name]
+  consume_topics   = { (kafka_topic.iam_identitydb_v1.name) : "iam-policy-decision-api" }
 }
 
 moved {
   from = module.iam_policy_decision_api.kafka_quota.producer_quota
   to   = module.iam_policy_decision_api.kafka_quota.quota
+}
+
+moved {
+  from = module.iam_identitydb_snapshotter_consumer.kafka_acl.group_acl
+  to   = module.iam_identitydb_snapshotter.kafka_acl.group_acl["auth.iam-identitydb-v1"]
+}
+
+moved {
+  from = module.iam_identitydb_snapshotter_consumer.kafka_acl.topic_acl
+  to   = module.iam_identitydb_snapshotter.kafka_acl.topic_acl["auth.iam-identitydb-v1"]
+}
+
+moved {
+  from = module.iam_identitydb_snapshotter_consumer.kafka_quota.consumer_quota
+  to   = module.iam_identitydb_snapshotter.kafka_quota.quota
+}
+
+moved {
+  from = module.iam_identitydb_identity_api_consumer.kafka_acl.topic_acl
+  to   = module.iam_identity_api.kafka_acl.topic_acl["auth.iam-identitydb-v1"]
+}
+
+moved {
+  from = module.iam_identitydb_identity_api_consumer.kafka_acl.group_acl
+  to   = module.iam_identity_api.kafka_acl.group_acl["auth.iam-identitydb-v1"]
+}
+
+moved {
+  from = module.iam_identitydb_identity_api_consumer.kafka_quota.consumer_quota
+  to   = module.iam_identity_api.kafka_quota.quota
+}
+
+moved {
+  from = module.iam_identitydb_event_forwarder_producer.kafka_acl.producer_acl
+  to   = module.iam_identitydb_event_forwarder.kafka_acl.producer_acl["auth.iam-identitydb-v1"]
+}
+
+moved {
+  from = module.iam_identitydb_event_forwarder_producer.kafka_quota.producer_quota
+  to   = module.iam_identitydb_event_forwarder.kafka_quota.quota
 }


### PR DESCRIPTION
Quotas need to be replaced, so there will be some disruption.

The plan is:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.iam_cerbos_audit_exporter_consumer.kafka_acl.group_acl has moved to module.iam_cerbos_audit_exporter.kafka_acl.group_acl["auth.iam-cerbos-audit-v1"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth/iam-cerbos-audit-exporter|*|Read|Allow|Group|exporter-iam-cerbos-audit-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_cerbos_audit_exporter_consumer.kafka_acl.topic_acl has moved to module.iam_cerbos_audit_exporter.kafka_acl.topic_acl["auth.iam-cerbos-audit-v1"]
    resource "kafka_acl" "topic_acl" {
        id                           = "User:CN=auth/iam-cerbos-audit-exporter|*|Read|Allow|Topic|auth.iam-cerbos-audit-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_cerbos_audit_exporter.kafka_quota.quota must be replaced
  # (moved from module.iam_cerbos_audit_exporter_consumer.kafka_quota.consumer_quota)
-/+ resource "kafka_quota" "quota" {
      ~ config      = { # forces replacement
          + "producer_byte_rate" = 5242880
            # (2 unchanged elements hidden)
        }
      ~ id          = "User:CN=auth/iam-cerbos-audit-exporter|user" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # module.iam_cerbos_audit_indexer_consumer.kafka_acl.group_acl has moved to module.iam_cerbos_audit_indexer.kafka_acl.group_acl["auth.iam-cerbos-audit-v1"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth/iam-cerbos-audit-indexer|*|Read|Allow|Group|indexer-iam-cerbos-audit-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_cerbos_audit_indexer_consumer.kafka_acl.topic_acl has moved to module.iam_cerbos_audit_indexer.kafka_acl.topic_acl["auth.iam-cerbos-audit-v1"]
    resource "kafka_acl" "topic_acl" {
        id                           = "User:CN=auth/iam-cerbos-audit-indexer|*|Read|Allow|Topic|auth.iam-cerbos-audit-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_cerbos_audit_indexer.kafka_quota.quota must be replaced
  # (moved from module.iam_cerbos_audit_indexer_consumer.kafka_quota.consumer_quota)
-/+ resource "kafka_quota" "quota" {
      ~ config      = { # forces replacement
          + "producer_byte_rate" = 5242880
            # (2 unchanged elements hidden)
        }
      ~ id          = "User:CN=auth/iam-cerbos-audit-indexer|user" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # module.iam_credentials_producer_auth_provider.kafka_acl.producer_acl has moved to module.iam_clubhouse_auth_provider.kafka_acl.producer_acl["auth-customer.iam-credentials-v1"]
    resource "kafka_acl" "producer_acl" {
        id                           = "User:CN=clubhouse/auth-provider|*|Write|Allow|Topic|auth-customer.iam-credentials-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_clubhouse_auth_provider.kafka_quota.quota must be replaced
  # (moved from module.iam_credentials_producer_auth_provider.kafka_quota.producer_quota)
-/+ resource "kafka_quota" "quota" {
      ~ config      = { # forces replacement
          + "consumer_byte_rate" = 5242880
            # (2 unchanged elements hidden)
        }
      ~ id          = "User:CN=clubhouse/auth-provider|user" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # module.iam_credentials_producer_api.kafka_acl.producer_acl has moved to module.iam_credentials_api.kafka_acl.producer_acl["auth-customer.iam-credentials-v1"]
    resource "kafka_acl" "producer_acl" {
        id                           = "User:CN=auth-customer/credentials-api|*|Write|Allow|Topic|auth-customer.iam-credentials-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_credentials_api.kafka_quota.quota must be replaced
  # (moved from module.iam_credentials_producer_api.kafka_quota.producer_quota)
-/+ resource "kafka_quota" "quota" {
      ~ config      = { # forces replacement
          + "consumer_byte_rate" = 5242880
            # (2 unchanged elements hidden)
        }
      ~ id          = "User:CN=auth-customer/credentials-api|user" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # module.iam_credentials_consumer.kafka_acl.group_acl has moved to module.iam_credentials_indexer.kafka_acl.group_acl["auth-customer.iam-credentials-v1"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth-customer/iam-credentials-v1-indexer|*|Read|Allow|Group|indexer-iam-credentials-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_credentials_consumer.kafka_acl.topic_acl has moved to module.iam_credentials_indexer.kafka_acl.topic_acl["auth-customer.iam-credentials-v1"]
    resource "kafka_acl" "topic_acl" {
        id                           = "User:CN=auth-customer/iam-credentials-v1-indexer|*|Read|Allow|Topic|auth-customer.iam-credentials-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_credentials_indexer.kafka_quota.quota must be replaced
  # (moved from module.iam_credentials_consumer.kafka_quota.consumer_quota)
-/+ resource "kafka_quota" "quota" {
      ~ config      = { # forces replacement
          + "producer_byte_rate" = 5242880
            # (2 unchanged elements hidden)
        }
      ~ id          = "User:CN=auth-customer/iam-credentials-v1-indexer|user" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # module.iam_identitydb_identity_api_consumer.kafka_acl.group_acl has moved to module.iam_identity_api.kafka_acl.group_acl["auth.iam-identitydb-v1"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth/iam-identity-api|*|Read|Allow|Group|iam-identity-api|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_identitydb_identity_api_consumer.kafka_acl.topic_acl has moved to module.iam_identity_api.kafka_acl.topic_acl["auth.iam-identitydb-v1"]
    resource "kafka_acl" "topic_acl" {
        id                           = "User:CN=auth/iam-identity-api|*|Read|Allow|Topic|auth.iam-identitydb-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_identity_api.kafka_quota.quota must be replaced
  # (moved from module.iam_identitydb_identity_api_consumer.kafka_quota.consumer_quota)
-/+ resource "kafka_quota" "quota" {
      ~ config      = { # forces replacement
          + "producer_byte_rate" = 5242880
            # (2 unchanged elements hidden)
        }
      ~ id          = "User:CN=auth/iam-identity-api|user" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # module.iam_identitydb_event_forwarder_producer.kafka_acl.producer_acl has moved to module.iam_identitydb_event_forwarder.kafka_acl.producer_acl["auth.iam-identitydb-v1"]
    resource "kafka_acl" "producer_acl" {
        id                           = "User:CN=auth/iam-identitydb-event-forwarder|*|Write|Allow|Topic|auth.iam-identitydb-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_identitydb_event_forwarder.kafka_quota.quota must be replaced
  # (moved from module.iam_identitydb_event_forwarder_producer.kafka_quota.producer_quota)
-/+ resource "kafka_quota" "quota" {
      ~ config      = { # forces replacement
          + "consumer_byte_rate" = 5242880
            # (2 unchanged elements hidden)
        }
      ~ id          = "User:CN=auth/iam-identitydb-event-forwarder|user" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # module.iam_identitydb_snapshotter_consumer.kafka_acl.group_acl has moved to module.iam_identitydb_snapshotter.kafka_acl.group_acl["auth.iam-identitydb-v1"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth/iam-identitydb-snapshotter|*|Read|Allow|Group|iam-identitydb-snapshotter|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_identitydb_snapshotter_consumer.kafka_acl.topic_acl has moved to module.iam_identitydb_snapshotter.kafka_acl.topic_acl["auth.iam-identitydb-v1"]
    resource "kafka_acl" "topic_acl" {
        id                           = "User:CN=auth/iam-identitydb-snapshotter|*|Read|Allow|Topic|auth.iam-identitydb-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_identitydb_snapshotter.kafka_quota.quota must be replaced
  # (moved from module.iam_identitydb_snapshotter_consumer.kafka_quota.consumer_quota)
-/+ resource "kafka_quota" "quota" {
      ~ config      = { # forces replacement
          + "producer_byte_rate" = 5242880
            # (2 unchanged elements hidden)
        }
      ~ id          = "User:CN=auth/iam-identitydb-snapshotter|user" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 8 to add, 0 to change, 8 to destroy.

```