### PR TITLE
Add `pre-commit` config to run `terraform fmt`

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,15 @@
+name: Checks
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: hashicorp/setup-terraform@v3.0.0
+    - uses: actions/setup-python@v5.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.86.0
+  hooks:
+    - id: terraform_fmt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+## Linting
+
+Linting is handled via `pre-commit`. Follow the [install
+instructions](https://pre-commit.com/#install), and additionally [install
+Terraform](https://developer.hashicorp.com/terraform/install) then install and
+run the hooks:
+
+``` console
+$ pre-commit install
+$ pre-commit run --all-hooks
+```

--- a/dev-aws/finance/debt.tf
+++ b/dev-aws/finance/debt.tf
@@ -41,7 +41,7 @@ resource "kafka_topic" "account-debt-events" {
 }
 
 resource "kafka_topic" "debt-collection-events" {
-  name = "debt-collection.events"
+  name               = "debt-collection.events"
   replication_factor = 3
   partitions         = 3
   config = {

--- a/dev-aws/finance/direct-debits.tf
+++ b/dev-aws/finance/direct-debits.tf
@@ -15,9 +15,9 @@ resource "kafka_topic" "dd_run_reconciliation_events" {
   partitions         = 10
   config = {
     "max.message.bytes" = "1048576"
-    "retention.bytes" = "-1"
-    "retention.ms"    = "259200000" #3 days, maybe worth doing it less
-    "cleanup.policy"  = "delete"
+    "retention.bytes"   = "-1"
+    "retention.ms"      = "259200000" #3 days, maybe worth doing it less
+    "cleanup.policy"    = "delete"
   }
 }
 

--- a/dev-aws/finance/disputes-fabricator.tf
+++ b/dev-aws/finance/disputes-fabricator.tf
@@ -10,7 +10,7 @@ resource "kafka_topic" "comms-eqdb-loader-events" {
 }
 
 resource "kafka_topic" "disputes-diffs-events" {
-  name = "disputes-diffs.events"
+  name               = "disputes-diffs.events"
   replication_factor = 3
   partitions         = 10
   config = {

--- a/dev-aws/kafka-shared/customer-billing.tf
+++ b/dev-aws/kafka-shared/customer-billing.tf
@@ -2,9 +2,9 @@ resource "kafka_topic" "invoice_fulfillment" {
   name               = "bex.internal.bill_fulfilled"
   replication_factor = 3
   partitions         = 10
-  config             = {
+  config = {
     # keep data for 7 days
-    "retention.ms"      = "604800000"
+    "retention.ms" = "604800000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"
@@ -16,9 +16,9 @@ resource "kafka_topic" "invoice_fulfillment_deadletter" {
   name               = "bex.internal.accountreadytobefulfilled_deadletter"
   replication_factor = 3
   partitions         = 10
-  config             = {
+  config = {
     # keep data for 14 days
-    "retention.ms"      = "1209600000"
+    "retention.ms" = "1209600000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"

--- a/dev-aws/kafka-shared/iam.tf
+++ b/dev-aws/kafka-shared/iam.tf
@@ -154,11 +154,11 @@ resource "kafka_topic" "iam_revoked_v1" {
   name               = "auth.iam-revoked-v1"
   replication_factor = 3
   partitions         = 1
-  config             = {
+  config = {
     # retain 100MB on each partition
-    "retention.bytes"   = "104857600"
+    "retention.bytes" = "104857600"
     # keep data for 7 days
-    "retention.ms"      = "604800000"
+    "retention.ms" = "604800000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"

--- a/dev-aws/kafka-shared/kafka-ui.tf
+++ b/dev-aws/kafka-shared/kafka-ui.tf
@@ -17,11 +17,11 @@ resource "kafka_acl" "kafka_ui_group" {
 }
 
 resource "kafka_acl" "kafka_ui_cluster" {
-  resource_name       = "kafka-cluster"
-  resource_type       = "Cluster"
-  acl_principal       = "User:CN=pubsub/kafka-ui"
-  acl_host            = "*"
-  acl_operation       = "All"
-  acl_permission_type = "Allow"
+  resource_name                = "kafka-cluster"
+  resource_type                = "Cluster"
+  acl_principal                = "User:CN=pubsub/kafka-ui"
+  acl_host                     = "*"
+  acl_operation                = "All"
+  acl_permission_type          = "Allow"
   resource_pattern_type_filter = "Literal"
 }

--- a/dev-aws/kafka-shared/mirror-maker.tf
+++ b/dev-aws/kafka-shared/mirror-maker.tf
@@ -17,11 +17,11 @@ resource "kafka_acl" "mirror_maker_group_access" {
 }
 
 resource "kafka_acl" "mirror_maker_cluster_access" {
-  resource_name       = "kafka-cluster"
-  resource_type       = "Cluster"
-  acl_principal       = "User:CN=pubsub/mirror-maker"
-  acl_host            = "*"
-  acl_operation       = "All"
-  acl_permission_type = "Allow"
+  resource_name                = "kafka-cluster"
+  resource_type                = "Cluster"
+  acl_principal                = "User:CN=pubsub/mirror-maker"
+  acl_host                     = "*"
+  acl_operation                = "All"
+  acl_permission_type          = "Allow"
   resource_pattern_type_filter = "Literal"
 }

--- a/dev-aws/kafka-shared/otel.tf
+++ b/dev-aws/kafka-shared/otel.tf
@@ -19,13 +19,13 @@ resource "kafka_topic" "otlp_spans" {
 }
 
 module "otel_collector" {
-  source = "../../modules/tls-app"
-  produce_topics = [kafka_topic.otlp_spans.name]
+  source           = "../../modules/tls-app"
+  produce_topics   = [kafka_topic.otlp_spans.name]
   cert_common_name = "otel/collector"
 }
 
 module "tempo_distributor" {
-  source = "../../modules/tls-app"
-  consume_topics = {(kafka_topic.otlp_spans.name): "processor-tempo"}
+  source           = "../../modules/tls-app"
+  consume_topics   = { (kafka_topic.otlp_spans.name) : "processor-tempo" }
   cert_common_name = "otel/tempo-distributor"
 }

--- a/dev-aws/kafka-shared/pubsub-examples.tf
+++ b/dev-aws/kafka-shared/pubsub-examples.tf
@@ -2,11 +2,11 @@ resource "kafka_topic" "pubsub_examples" {
   name               = "dev-enablement.pubsub-examples"
   replication_factor = 3
   partitions         = 10
-  config             = {
+  config = {
     # retain 100MB on each partition
-    "retention.bytes"   = "104857600"
+    "retention.bytes" = "104857600"
     # keep data for 2 days
-    "retention.ms"      = "172800000"
+    "retention.ms" = "172800000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"

--- a/exp-1-merit/kafka-shared/kafka-ui.tf
+++ b/exp-1-merit/kafka-shared/kafka-ui.tf
@@ -17,11 +17,11 @@ resource "kafka_acl" "kafka_ui_group" {
 }
 
 resource "kafka_acl" "kafka_ui_cluster" {
-  resource_name       = "kafka-cluster"
-  resource_type       = "Cluster"
-  acl_principal       = "User:CN=pubsub/kafka-ui"
-  acl_host            = "*"
-  acl_operation       = "All"
-  acl_permission_type = "Allow"
+  resource_name                = "kafka-cluster"
+  resource_type                = "Cluster"
+  acl_principal                = "User:CN=pubsub/kafka-ui"
+  acl_host                     = "*"
+  acl_operation                = "All"
+  acl_permission_type          = "Allow"
   resource_pattern_type_filter = "Literal"
 }

--- a/exp-1-merit/kafka-shared/pdp-audit.tf
+++ b/exp-1-merit/kafka-shared/pdp-audit.tf
@@ -5,9 +5,9 @@ resource "kafka_topic" "iam_cerbos_audit_v1" {
 
   config = {
     # retain 100MB on each partition
-    "retention.bytes"   = "104857600"
+    "retention.bytes" = "104857600"
     # keep data for 2 days
-    "retention.ms"      = "172800000"
+    "retention.ms" = "172800000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"

--- a/exp-1-merit/kafka-shared/pubsub-examples.tf
+++ b/exp-1-merit/kafka-shared/pubsub-examples.tf
@@ -9,8 +9,8 @@ resource "kafka_topic" "pubsub_examples" {
     "retention.ms" = "172800000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
-    "compression.type" = "zstd"
-    "cleanup.policy"   = "delete"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
   }
 }
 
@@ -24,8 +24,8 @@ resource "kafka_acl" "example_producer_topic_access" {
 }
 
 resource "kafka_quota" "example_producer_quota" {
-  entity_name               = "User:CN=pubsub/example-producer"
-  entity_type               = "user"
+  entity_name = "User:CN=pubsub/example-producer"
+  entity_type = "user"
   config = {
     # limit producing to 5 MB/s
     "producer_byte_rate" = "5242880"
@@ -53,8 +53,8 @@ resource "kafka_acl" "example_consume_process_individually_group_access" {
 }
 
 resource "kafka_quota" "example_consume_process_individually_quota" {
-  entity_name               = "User:CN=pubsub/example-consume-process-individually"
-  entity_type               = "user"
+  entity_name = "User:CN=pubsub/example-consume-process-individually"
+  entity_type = "user"
   config = {
     # limit consuming to 5 MB/s
     "consumer_byte_rate" = "5242880"

--- a/exp-1-merit/pubsub-msk/kafka-ui.tf
+++ b/exp-1-merit/pubsub-msk/kafka-ui.tf
@@ -17,12 +17,12 @@ resource "kafka_acl" "kafka_ui_group" {
 }
 
 resource "kafka_acl" "kafka_ui_cluster" {
-  resource_name       = "kafka-cluster"
-  resource_type       = "Cluster"
-  acl_principal       = "User:CN=pubsub/kafka-ui"
-  acl_host            = "*"
-  acl_operation       = "All"
-  acl_permission_type = "Allow"
+  resource_name                = "kafka-cluster"
+  resource_type                = "Cluster"
+  acl_principal                = "User:CN=pubsub/kafka-ui"
+  acl_host                     = "*"
+  acl_operation                = "All"
+  acl_permission_type          = "Allow"
   resource_pattern_type_filter = "Literal"
 
   depends_on = [kafka_acl.tf_applier_cluster]

--- a/exp-1-merit/pubsub-msk/pubsub-examples.tf
+++ b/exp-1-merit/pubsub-msk/pubsub-examples.tf
@@ -12,8 +12,8 @@ resource "kafka_topic" "pubsub_examples" {
     "local.retention.ms" = "3600000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
-    "compression.type" = "zstd"
-    "cleanup.policy"   = "delete"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
   }
 }
 
@@ -27,8 +27,8 @@ resource "kafka_acl" "example_producer_topic_access" {
 }
 
 resource "kafka_quota" "example_producer_quota" {
-  entity_name               = "User:CN=pubsub/example-producer"
-  entity_type               = "user"
+  entity_name = "User:CN=pubsub/example-producer"
+  entity_type = "user"
   config = {
     # limit producing to 5 MB/s
     "producer_byte_rate" = "5242880"
@@ -56,8 +56,8 @@ resource "kafka_acl" "example_consume_process_individually_group_access" {
 }
 
 resource "kafka_quota" "example_consume_process_individually_quota" {
-  entity_name               = "User:CN=pubsub/example-consume-process-individually"
-  entity_type               = "user"
+  entity_name = "User:CN=pubsub/example-consume-process-individually"
+  entity_type = "user"
   config = {
     # limit consuming to 5 MB/s
     "consumer_byte_rate" = "5242880"

--- a/exp-1-merit/pubsub-msk/tf-applier.tf
+++ b/exp-1-merit/pubsub-msk/tf-applier.tf
@@ -17,11 +17,11 @@ resource "kafka_acl" "tf_applier_group" {
 }
 
 resource "kafka_acl" "tf_applier_cluster" {
-  resource_name       = "kafka-cluster"
-  resource_type       = "Cluster"
-  acl_principal       = "User:CN=pubsub/tf-applier"
-  acl_host            = "*"
-  acl_operation       = "All"
-  acl_permission_type = "Allow"
+  resource_name                = "kafka-cluster"
+  resource_type                = "Cluster"
+  acl_principal                = "User:CN=pubsub/tf-applier"
+  acl_host                     = "*"
+  acl_operation                = "All"
+  acl_permission_type          = "Allow"
   resource_pattern_type_filter = "Literal"
 }

--- a/modules/tls-app/main.tf
+++ b/modules/tls-app/main.tf
@@ -34,7 +34,7 @@ resource "kafka_acl" "producer_acl" {
 resource "kafka_quota" "quota" {
   entity_name = "User:CN=${var.cert_common_name}"
   entity_type = "user"
-  config      = {
+  config = {
     "consumer_byte_rate" = tostring(var.consumer_byte_rate)
     "producer_byte_rate" = tostring(var.producer_byte_rate)
     "request_percentage" = tostring(var.request_percentage)

--- a/modules/tls-app/variables.tf
+++ b/modules/tls-app/variables.tf
@@ -49,7 +49,7 @@ variable "request_percentage" {
   type        = number
   description = "The percentage of requests a specified entity is allowed to make."
   # Allow 100% of CPU. More on this here: https://docs.confluent.io/kafka/design/quotas.html#request-rate-quotas
-  default     = 100
+  default = 100
 
   validation {
     condition     = var.request_percentage >= 0 && var.request_percentage <= 100

--- a/prod-aws/finance/complaints-fabricator.tf
+++ b/prod-aws/finance/complaints-fabricator.tf
@@ -15,7 +15,7 @@ resource "kafka_topic" "complaints-eqdb-loader-events" {
   partitions         = 10
   config = {
     "retention.bytes" = "-1"
-    "retention.ms"    = "-1" 
+    "retention.ms"    = "-1"
     "cleanup.policy"  = "delete"
   }
 }

--- a/prod-aws/finance/debt.tf
+++ b/prod-aws/finance/debt.tf
@@ -41,7 +41,7 @@ resource "kafka_topic" "account-debt-events" {
 }
 
 resource "kafka_topic" "debt-collection-events" {
-  name = "debt-collection.events"
+  name               = "debt-collection.events"
   replication_factor = 3
   partitions         = 10
   config = {

--- a/prod-aws/finance/disputes-fabricator.tf
+++ b/prod-aws/finance/disputes-fabricator.tf
@@ -10,7 +10,7 @@ resource "kafka_topic" "comms-eqdb-loader-events" {
 }
 
 resource "kafka_topic" "disputes-diffs-v1-events" {
-  name = "disputes-diffs.v1-events"
+  name               = "disputes-diffs.v1-events"
   replication_factor = 3
   partitions         = 10
   config = {

--- a/prod-aws/kafka-shared/customer-billing.tf
+++ b/prod-aws/kafka-shared/customer-billing.tf
@@ -2,9 +2,9 @@ resource "kafka_topic" "invoice_fulfillment" {
   name               = "bex.internal.bill_fulfilled"
   replication_factor = 3
   partitions         = 10
-  config             = {
+  config = {
     # keep data for 7 days
-    "retention.ms"      = "604800000"
+    "retention.ms" = "604800000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"
@@ -16,9 +16,9 @@ resource "kafka_topic" "invoice_fulfillment_deadletter" {
   name               = "bex.internal.accountreadytobefulfilled_deadletter"
   replication_factor = 3
   partitions         = 10
-  config             = {
+  config = {
     # keep data for 14 days
-    "retention.ms"      = "1209600000"
+    "retention.ms" = "1209600000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"

--- a/prod-aws/kafka-shared/iam.tf
+++ b/prod-aws/kafka-shared/iam.tf
@@ -113,9 +113,9 @@ resource "kafka_topic" "iam_revoked_v1" {
   name               = "auth.iam-revoked-v1"
   replication_factor = 3
   partitions         = 1
-  config             = {
+  config = {
     # retain 100MB on each partition
-    "retention.bytes"   = "104857600"
+    "retention.bytes" = "104857600"
     # keep data for 60 days
     "retention.ms" = "5184000000"
     # allow max 1 MB for a message

--- a/prod-aws/kafka-shared/kafka-ui.tf
+++ b/prod-aws/kafka-shared/kafka-ui.tf
@@ -17,11 +17,11 @@ resource "kafka_acl" "kafka_ui_group" {
 }
 
 resource "kafka_acl" "kafka_ui_cluster" {
-  resource_name       = "kafka-cluster"
-  resource_type       = "Cluster"
-  acl_principal       = "User:CN=pubsub/kafka-ui"
-  acl_host            = "*"
-  acl_operation       = "All"
-  acl_permission_type = "Allow"
+  resource_name                = "kafka-cluster"
+  resource_type                = "Cluster"
+  acl_principal                = "User:CN=pubsub/kafka-ui"
+  acl_host                     = "*"
+  acl_operation                = "All"
+  acl_permission_type          = "Allow"
   resource_pattern_type_filter = "Literal"
 }

--- a/prod-aws/kafka-shared/mirror-maker.tf
+++ b/prod-aws/kafka-shared/mirror-maker.tf
@@ -17,11 +17,11 @@ resource "kafka_acl" "mirror_maker_group_access" {
 }
 
 resource "kafka_acl" "mirror_maker_cluster_access" {
-  resource_name       = "kafka-cluster"
-  resource_type       = "Cluster"
-  acl_principal       = "User:CN=pubsub/mirror-maker"
-  acl_host            = "*"
-  acl_operation       = "All"
-  acl_permission_type = "Allow"
+  resource_name                = "kafka-cluster"
+  resource_type                = "Cluster"
+  acl_principal                = "User:CN=pubsub/mirror-maker"
+  acl_host                     = "*"
+  acl_operation                = "All"
+  acl_permission_type          = "Allow"
   resource_pattern_type_filter = "Literal"
 }

--- a/prod-aws/kafka-shared/otel.tf
+++ b/prod-aws/kafka-shared/otel.tf
@@ -12,21 +12,21 @@ resource "kafka_topic" "otlp_spans" {
     # roll log at 3h max
     "segment.ms" = "10800000"
     # max log size of 250 MB
-    "segment.bytes"    = "262144000"
-    "compression.type" = "zstd"
-    "cleanup.policy"   = "delete"
+    "segment.bytes"                  = "262144000"
+    "compression.type"               = "zstd"
+    "cleanup.policy"                 = "delete"
     "unclean.leader.election.enable" = "false"
   }
 }
 
 module "otel_collector" {
-  source = "../../modules/tls-app"
-  produce_topics = [kafka_topic.otlp_spans.name]
+  source           = "../../modules/tls-app"
+  produce_topics   = [kafka_topic.otlp_spans.name]
   cert_common_name = "otel/collector"
 }
 
 module "tempo_distributor" {
-  source = "../../modules/tls-app"
-  consume_topics = {(kafka_topic.otlp_spans.name): "processor-tempo"}
+  source           = "../../modules/tls-app"
+  consume_topics   = { (kafka_topic.otlp_spans.name) : "processor-tempo" }
   cert_common_name = "otel/tempo-distributor"
 }


### PR DESCRIPTION
Run the hook to format all the code and enforce this via CI to avoid
regressions. This is to keep formatting consistent and not a thing to
worry/think about when developing or in PRs.

This does rely on the local version of `terraform` people are running. I
think this can cause issues when running `terraform apply` across
different versions, but it should be fine for `terraform fmt` which I
can't imagine changes output much between versions.