### PR TITLE
[DENA-427] recreate es-topic-indexer policy for pubsub-exapmles

### DIFF
--- a/dev-aws/kafka-shared/pubsub-examples.tf
+++ b/dev-aws/kafka-shared/pubsub-examples.tf
@@ -31,3 +31,9 @@ module "example_process_batch_consumer" {
   consume_topics   = { (kafka_topic.pubsub_examples.name) : "example-consume-process-batch" }
   cert_common_name = "dev-enablement/example-consume-process-batch"
 }
+
+module "es_topic_indexer" {
+  source           = "../../modules/tls-app"
+  consume_topics   = { (kafka_topic.pubsub_examples.name) : "es-topic-indexer" }
+  cert_common_name = "dev-enablement/es-topic-indexer"
+}

--- a/dev-aws/kafka-shared/pubsub-examples.tf
+++ b/dev-aws/kafka-shared/pubsub-examples.tf
@@ -34,6 +34,6 @@ module "example_process_batch_consumer" {
 
 module "es_topic_indexer" {
   source           = "../../modules/tls-app"
-  consume_topics   = { (kafka_topic.pubsub_examples.name) : "es-topic-indexer" }
+  consume_topics   = { (kafka_topic.pubsub_examples.name) : "dev-enablement.es-topic-indexer" }
   cert_common_name = "dev-enablement/es-topic-indexer"
 }


### PR DESCRIPTION
Looks like the contents of this PR were accidentally deleted during moving to modules: 
https://github.com/utilitywarehouse/kafka-cluster-config/pull/114

I assume, now changes to dev-merit should be added to dev-aws.

`make-plan` output:

```
Terraform will perform the following actions:

  # module.es_topic_indexer.kafka_acl.group_acl["dev-enablement.pubsub-examples"] will be created
  + resource "kafka_acl" "group_acl" {
      + acl_host                     = "*"
      + acl_operation                = "Read"
      + acl_permission_type          = "Allow"
      + acl_principal                = "User:CN=dev-enablement/es-topic-indexer"
      + id                           = (known after apply)
      + resource_name                = "es-topic-indexer"
      + resource_pattern_type_filter = "Literal"
      + resource_type                = "Group"
    }

  # module.es_topic_indexer.kafka_acl.topic_acl["dev-enablement.pubsub-examples"] will be created
  + resource "kafka_acl" "topic_acl" {
      + acl_host                     = "*"
      + acl_operation                = "Read"
      + acl_permission_type          = "Allow"
      + acl_principal                = "User:CN=dev-enablement/es-topic-indexer"
      + id                           = (known after apply)
      + resource_name                = "dev-enablement.pubsub-examples"
      + resource_pattern_type_filter = "Literal"
      + resource_type                = "Topic"
    }

  # module.es_topic_indexer.kafka_quota.quota will be created
  + resource "kafka_quota" "quota" {
      + config      = {
          + "consumer_byte_rate" = 5242880
          + "producer_byte_rate" = 5242880
          + "request_percentage" = 100
        }
      + entity_name = "User:CN=dev-enablement/es-topic-indexer"
      + entity_type = "user"
      + id          = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```

