### PR TITLE
PLA2-70: kafka-shared: moved tf module settings to a single file

### DIFF
--- a/dev-aws/kafka-shared/__env.tf
+++ b/dev-aws/kafka-shared/__env.tf
@@ -1,4 +1,6 @@
 terraform {
+  backend "s3" {}
+
   required_providers {
     kafka = {
       source = "Mongey/kafka"

--- a/dev-aws/kafka-shared/backend.tf
+++ b/dev-aws/kafka-shared/backend.tf
@@ -1,3 +1,0 @@
-terraform {
-  backend "s3" {}
-}

--- a/prod-aws/kafka-shared/__env.tf
+++ b/prod-aws/kafka-shared/__env.tf
@@ -1,4 +1,7 @@
 terraform {
+
+  backend "s3" {}
+
   required_providers {
     kafka = {
       source = "Mongey/kafka"

--- a/prod-aws/kafka-shared/backend.tf
+++ b/prod-aws/kafka-shared/backend.tf
@@ -1,3 +1,0 @@
-terraform {
-  backend "s3" {}
-}


### PR DESCRIPTION
Using the same name "__env.tf" as in the terraform repo https://github.com/utilitywarehouse/terraform 