### PR TITLE
PLA2-76: pubsub examples: add team prefix to the consumer groups

### DIFF
--- a/dev-aws/kafka-shared/dev-enablement/pubsub-examples.tf
+++ b/dev-aws/kafka-shared/dev-enablement/pubsub-examples.tf
@@ -22,13 +22,13 @@ module "example_producer" {
 
 module "example_process_individually_consumer" {
   source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.pubsub_examples.name) : "example-consume-process-individually" }
+  consume_topics   = { (kafka_topic.pubsub_examples.name) : "dev-enablement.example-consume-process-individually" }
   cert_common_name = "dev-enablement/example-consume-process-individually"
 }
 
 module "example_process_batch_consumer" {
   source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.pubsub_examples.name) : "example-consume-process-batch" }
+  consume_topics   = { (kafka_topic.pubsub_examples.name) : "dev-enablement.example-consume-process-batch" }
   cert_common_name = "dev-enablement/example-consume-process-batch"
 }
 


### PR DESCRIPTION
To be in line with the guidelines https://github.com/utilitywarehouse/kafka-cluster-config/tree/dev-enablement-fix-consumer-groups/dev-aws/kafka-shared#contributing.