### PR TITLE
Add basic topic config for energy-budget-plan namespace

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-budget-plan/Makefile
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/Makefile
@@ -1,0 +1,1 @@
+include ../../../lib/kafka-shared/Makefile

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/__env.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/__env.tf
@@ -1,0 +1,17 @@
+terraform {
+  backend "s3" {}
+
+  required_providers {
+    kafka = {
+      source = "Mongey/kafka"
+    }
+  }
+}
+
+provider "kafka" {
+  bootstrap_servers = [
+    "b-1.devenablementpubsubmsk.xmhf7r.c8.kafka.eu-west-1.amazonaws.com:9094",
+    "b-2.devenablementpubsubmsk.xmhf7r.c8.kafka.eu-west-1.amazonaws.com:9094",
+    "b-3.devenablementpubsubmsk.xmhf7r.c8.kafka.eu-west-1.amazonaws.com:9094",
+  ]
+}

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -53,8 +53,8 @@ resource "kafka_topic" "customer_change" {
     "remote.storage.enable" = "true"
     # keep data for 2 years
     "retention.ms" = "63113852000"
-    # keep data in hot storage for 2 days
-    "local.retention.ms" = "172800000"
+    # keep data in hot storage for 7 days
+    "local.retention.ms" = "604800000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -14,18 +14,6 @@ resource "kafka_topic" "eqdb_loader" {
   }
 }
 
-module "eqdb_loader_process" {
-  source           = "../../../modules/tls-app"
-  produce_topics   = [kafka_topic.eqdb_loader.name]
-  cert_common_name = "energy-budget-plan/eqdb-loader"
-}
-
-module "budget_plan_fabricator" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.eqdb_loader.name) : "energy-budget-plan.eqdb-fabricator-v1" }
-  cert_common_name = "energy-budget-plan/eqdb-fabricator"
-}
-
 resource "kafka_topic" "budget_plan" {
   name               = "energy-budget-plan.budget-plan"
   replication_factor = 3
@@ -62,8 +50,22 @@ resource "kafka_topic" "customer_change" {
   }
 }
 
+module "eqdb_loader_process" {
+  source           = "../../../modules/tls-app"
+  produce_topics   = [kafka_topic.eqdb_loader.name]
+  cert_common_name = "energy-budget-plan/eqdb-loader"
+}
+
+module "budget_plan_fabricator" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = { (kafka_topic.eqdb_loader.name) : "energy-budget-plan.eqdb-fabricator-v1" }
+  produce_topics   = [kafka_topic.customer_change.name]
+  cert_common_name = "energy-budget-plan/eqdb-fabricator"
+}
+
 module "budget_plan_calculator" {
   source           = "../../../modules/tls-app"
   consume_topics   = { (kafka_topic.budget_plan.name) : "energy-budget-plan.calculator-v1" }
+  produce_topics   = [kafka_topic.budget_plan.name]
   cert_common_name = "energy-budget-plan/calculator"
 }

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -1,4 +1,4 @@
-resource "kafka_topic" "eqbd_loader" {
+resource "kafka_topic" "eqdb_loader" {
   name               = "energy-budget-plan.eqdb-loader"
   replication_factor = 3
   partitions         = 1
@@ -16,13 +16,13 @@ resource "kafka_topic" "eqbd_loader" {
 
 module "eqdb_loader_process" {
   source           = "../../../modules/tls-app"
-  produce_topics   = [kafka_topic.eqbd_loader.name]
+  produce_topics   = [kafka_topic.eqdb_loader.name]
   cert_common_name = "energy-budget-plan/eqdb-loader"
 }
 
 module "budget_plan_fabricator" {
   source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.eqbd_loader.name) : "energy-budget-plan.eqdb-fabricator-v1" }
+  consume_topics   = { (kafka_topic.eqdb_loader.name) : "energy-budget-plan.eqdb-fabricator-v1" }
   cert_common_name = "energy-budget-plan/eqdb-fabricator"
 }
 

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -31,10 +31,12 @@ resource "kafka_topic" "budget_plan" {
   replication_factor = 3
   partitions         = 10
   config = {
-    # no limit on retention size, using time based instead
-    "retention.bytes" = "-1"
+    # Use tiered storage
+    "remote.storage.enable" = "true"
     # keep data for 7 years
     "retention.ms" = "220898482000"
+    # keep data in hot storage for 2 days
+    "local.retention.ms" = "172800000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"
@@ -47,10 +49,12 @@ resource "kafka_topic" "customer_change" {
   replication_factor = 3
   partitions         = 10
   config = {
-    # no limit on retention size, using time based instead
-    "retention.bytes" = "-1"
+    # Use tiered storage
+    "remote.storage.enable" = "true"
     # keep data for 2 years
     "retention.ms" = "63113852000"
+    # keep data in hot storage for 2 days
+    "local.retention.ms" = "172800000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -26,23 +26,15 @@ module "budget_plan_fabricator" {
   cert_common_name = "energy-budget-plan/eqdb-fabricator"
 }
 
-#- max_message_bytes: "104857600" - 100MB !
-#  max_retention_bytes: "805306368000" - 768000MB !
-#  name: budget-plan
-#  partitions: 10
-#  replication_factor: 3
-#  topic_compression: snappy
-#  max_retention_time: "3024000000"
-
 resource "kafka_topic" "budget_plan" {
   name               = "energy-budget-plan.budget-plan"
   replication_factor = 3
   partitions         = 10
   config = {
-    # retain 100MB on each partition - TODO
-    "retention.bytes" = "104857600"
-    # keep data for 5 weeks
-    "retention.ms" = "3024000000"
+    # no limit on retention size, using time based instead
+    "retention.bytes" = "-1"
+    # keep data for 7 years
+    "retention.ms" = "220898482000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"
@@ -50,22 +42,15 @@ resource "kafka_topic" "budget_plan" {
   }
 }
 
-#- max_message_bytes: "104857600" - 100MB !
-#  max_retention_bytes: "805306368000" - 768000MB !
-#  name: customer-change
-#  partitions: 10
-#  replication_factor: 3
-#  topic_compression: snappy
-
 resource "kafka_topic" "customer_change" {
   name               = "energy-budget-plan.customer-change"
   replication_factor = 3
   partitions         = 10
   config = {
-    # retain 100MB on each partition - TODO
-    "retention.bytes" = "104857600"
-    # keep data for 5 weeks - TODO not set in Kafka Topic applier https://github.com/utilitywarehouse/kubernetes-manifests/blob/d632983de4052ff8f33ccdd37ba886a16b322a49/prod-aws/customer-billing/kafka-topic-applier/topics.yaml#L98-L103
-    "retention.ms" = "3024000000"
+    # no limit on retention size, using time based instead
+    "retention.bytes" = "-1"
+    # keep data for 2 years
+    "retention.ms" = "63113852000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -23,7 +23,7 @@ module "eqdb_loader_process" {
 module "budget_plan_fabricator" {
   source           = "../../../modules/tls-app"
   consume_topics   = { (kafka_topic.eqbd_loader.name) : "energy-budget-plan.eqdb-fabricator-v1" }
-  cert_common_name = "energy-budget-plan/budget-plan-eqdb-fabricator"
+  cert_common_name = "energy-budget-plan/eqdb-fabricator"
 }
 
 #- max_message_bytes: "104857600" - 100MB !
@@ -50,8 +50,8 @@ resource "kafka_topic" "budget_plan" {
   }
 }
 
-#- max_message_bytes: "104857600"
-#  max_retention_bytes: "805306368000"
+#- max_message_bytes: "104857600" - 100MB !
+#  max_retention_bytes: "805306368000" - 768000MB !
 #  name: customer-change
 #  partitions: 10
 #  replication_factor: 3

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -1,0 +1,74 @@
+resource "kafka_topic" "eqbd_loader" {
+  name               = "energy-budget-plan.eqdb-loader"
+  replication_factor = 3
+  partitions         = 1
+  config = {
+    # retain 100MB on each partition
+    "retention.bytes" = "104857600"
+    # keep data for 18 hours
+    "retention.ms" = "64800000"
+    # allow max 1 MB for a message
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+module "eqdb_loader_process" {
+  source           = "../../../modules/tls-app"
+  produce_topics   = [kafka_topic.eqbd_loader.name]
+  cert_common_name = "energy-budget-plan/eqdb-loader"
+}
+
+module "budget_plan_fabricator" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = { (kafka_topic.eqbd_loader.name) : "energy-budget-plan.eqdb-fabricator-v1" }
+  cert_common_name = "energy-budget-plan/budget-plan-eqdb-fabricator"
+}
+
+#- max_message_bytes: "104857600" - 100MB !
+#  max_retention_bytes: "805306368000" - 768000MB !
+#  name: budget-plan
+#  partitions: 10
+#  replication_factor: 3
+#  topic_compression: snappy
+#  max_retention_time: "3024000000"
+
+resource "kafka_topic" "budget_plan" {
+  name               = "energy-budget-plan.budget-plan"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    # retain 100MB on each partition - TODO
+    "retention.bytes" = "104857600"
+    # keep data for 5 weeks
+    "retention.ms" = "3024000000"
+    # allow max 1 MB for a message
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+#- max_message_bytes: "104857600"
+#  max_retention_bytes: "805306368000"
+#  name: customer-change
+#  partitions: 10
+#  replication_factor: 3
+#  topic_compression: snappy
+
+resource "kafka_topic" "customer_change" {
+  name               = "energy-budget-plan.customer-change"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    # retain 100MB on each partition - TODO
+    "retention.bytes" = "104857600"
+    # keep data for 5 weeks - TODO not set in Kafka Topic applier https://github.com/utilitywarehouse/kubernetes-manifests/blob/d632983de4052ff8f33ccdd37ba886a16b322a49/prod-aws/customer-billing/kafka-topic-applier/topics.yaml#L98-L103
+    "retention.ms" = "3024000000"
+    # allow max 1 MB for a message
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -61,3 +61,9 @@ resource "kafka_topic" "customer_change" {
     "cleanup.policy"    = "delete"
   }
 }
+
+module "budget_plan_calculator" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = { (kafka_topic.budget_plan.name) : "energy-budget-plan.calculator-v1" }
+  cert_common_name = "energy-budget-plan/calculator"
+}


### PR DESCRIPTION
- Creates 3 topics for energy-budget-plan: `energy-budget-plan.eqdb-loader`, `energy-budget-plan.budget-plan` and `energy-budget-plan.customer-change`
- Configures an EQDB loader process as producer on `energy-budget-plan.eqdb-loader`
- Configures a Budget Plan Fabricator process as the consumer of `energy-budget-plan.eqdb-loader` and producer on `energy-budget-plan.customer-change`
- Configures Budge Plan Calculator as consumer and producer of `energy-budget-plan.budget-plan`
- Cert config in wip PR https://github.com/utilitywarehouse/kubernetes-manifests/pull/85143
