### PR TITLE
shared msk dev - mm2 acls need to be applied after tf-applier acls

### DIFF
--- a/dev-aws/kafka-shared-msk/pubsub/mirror-maker.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/mirror-maker.tf
@@ -24,4 +24,6 @@ resource "kafka_acl" "mirror_maker_cluster_access" {
   acl_operation                = "All"
   acl_permission_type          = "Allow"
   resource_pattern_type_filter = "Literal"
+
+  depends_on = [kafka_acl.tf_applier_cluster]
 }


### PR DESCRIPTION
shared msk dev - mm2 acls need to be applied after tf-applier acls otherwise
tf-applier principal looses cluster permissions and bootstrap fails