### PR TITLE
Set compaction lag to two hours

### DIFF
--- a/prod-aws/finance/account-balance.tf
+++ b/prod-aws/finance/account-balance.tf
@@ -56,7 +56,7 @@ resource "kafka_topic" "account-balance-change-v2-events" {
   config = {
     "cleanup.policy"        = "compact"
     "max.message.bytes"     = "104857600"
-    "max.compaction.lag.ms" = "1728000000"
+    "max.compaction.lag.ms" = "7200000"
   }
 }
 


### PR DESCRIPTION
At first, I thought 20 days would work but I was not thinking about the current use case where we copy messages from the old topic and expect them to be compacted when a new version is published. 