### PR TITLE
PLA2-83: tls-app module: allow same consumer group for multiple topics

### DIFF
--- a/dev-aws/kafka-shared/dev-enablement/pubsub-examples.tf
+++ b/dev-aws/kafka-shared/dev-enablement/pubsub-examples.tf
@@ -15,25 +15,43 @@ resource "kafka_topic" "pubsub_examples" {
 }
 
 module "example_producer" {
-  source           = "../../../modules/tls-app"
+  source           = "../../../modules/tls-app-v2"
   produce_topics   = [kafka_topic.pubsub_examples.name]
   cert_common_name = "dev-enablement/example-producer"
 }
 
 module "example_process_individually_consumer" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.pubsub_examples.name) : "dev-enablement.example-consume-process-individually" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.pubsub_examples.name)]
+  consume_groups   = ["dev-enablement.example-consume-process-individually"]
   cert_common_name = "dev-enablement/example-consume-process-individually"
 }
 
 module "example_process_batch_consumer" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.pubsub_examples.name) : "dev-enablement.example-consume-process-batch" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.pubsub_examples.name)]
+  consume_groups   = ["dev-enablement.example-consume-process-batch"]
   cert_common_name = "dev-enablement/example-consume-process-batch"
 }
 
 module "es_topic_indexer" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.pubsub_examples.name) : "dev-enablement.es-topic-indexer" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.pubsub_examples.name)]
+  consume_groups   = ["dev-enablement.es-topic-indexer"]
   cert_common_name = "dev-enablement/es-topic-indexer"
+}
+
+moved {
+  from = module.example_process_individually_consumer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
+  to   = module.example_process_individually_consumer.kafka_acl.group_acl["dev-enablement.example-consume-process-individually"]
+}
+
+moved {
+  from = module.example_process_batch_consumer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
+  to   = module.example_process_batch_consumer.kafka_acl.group_acl["dev-enablement.example-consume-process-batch"]
+}
+
+moved {
+  from = module.es_topic_indexer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
+  to   = module.es_topic_indexer.kafka_acl.group_acl["dev-enablement.es-topic-indexer"]
 }

--- a/modules/tls-app-v2/README.md
+++ b/modules/tls-app-v2/README.md
@@ -1,0 +1,18 @@
+# TLS app Terraform module
+
+This module defines the ACLs and quota needed by an app to communicate with an mTLS enabled kafka cluster.
+
+See [main.tf](main.tf) for what resources it defines and [variables.tf](variables.tf) for available input variables.
+
+## Usage example:
+Following the [name prefix guidelines](../../prod-aws/kafka-shared/README.md#contributing)
+ ```terraform
+ module "example" {
+   source           = "../../modules/tls-app"
+   consume_topics   = ["dev-enablement.example-topic1", "dev-enablement.example-topic2"]
+   consume_groups   = ["dev-enablement.example-consumer-group1", "dev-enablement.example-consumer-group2"]
+   produce_topics   = ["dev-enablement.example-produce-topic"]
+   cert_common_name = "dev-enablement/example-app"
+ }
+ ```
+

--- a/modules/tls-app-v2/README.md
+++ b/modules/tls-app-v2/README.md
@@ -5,14 +5,26 @@ This module defines the ACLs and quota needed by an app to communicate with an m
 See [main.tf](main.tf) for what resources it defines and [variables.tf](variables.tf) for available input variables.
 
 ## Usage example:
-Following the [name prefix guidelines](../../prod-aws/kafka-shared/README.md#contributing)
- ```terraform
- module "example" {
-   source           = "../../modules/tls-app"
-   consume_topics   = ["dev-enablement.example-topic1", "dev-enablement.example-topic2"]
-   consume_groups   = ["dev-enablement.example-consumer-group1", "dev-enablement.example-consumer-group2"]
-   produce_topics   = ["dev-enablement.example-produce-topic"]
-   cert_common_name = "dev-enablement/example-app"
- }
- ```
-
+Following the [name prefix guidelines](../../prod-aws/kafka-shared/README.md#contributing):
+1. using default quota values:
+     ```terraform
+     module "example" {
+       source           = "../../modules/tls-app"
+       consume_topics   = ["dev-enablement.example-topic1", "dev-enablement.example-topic2"]
+       consume_groups   = ["dev-enablement.example-consumer-group1", "dev-enablement.example-consumer-group2"]
+       produce_topics   = ["dev-enablement.example-produce-topic"]
+       cert_common_name = "dev-enablement/example-app"
+     }
+     ```
+2. specify quota values
+     ```terraform
+     module "example" {
+       source           = "../../modules/tls-app"
+       consume_topics   = ["dev-enablement.example-topic1", "dev-enablement.example-topic2"]
+       consume_groups   = ["dev-enablement.example-consumer-group1", "dev-enablement.example-consumer-group2"]
+       produce_topics   = ["dev-enablement.example-produce-topic"]
+       consumer_byte_rate = 3145728 #  limit consuming to 3 MB/s
+       producer_byte_rate = 4194304 # Limit producing to 4 MB/s
+       cert_common_name = "dev-enablement/example-app"
+     }
+     ```

--- a/modules/tls-app-v2/main.tf
+++ b/modules/tls-app-v2/main.tf
@@ -9,7 +9,7 @@ resource "kafka_acl" "topic_acl" {
   acl_permission_type = "Allow"
 }
 
-# For each consumed topic define an ACL for accessing the consumer group
+# For each used consumer group define an ACL for accessing it
 resource "kafka_acl" "group_acl" {
   for_each            = toset(var.consume_groups)
   resource_name       = each.key

--- a/modules/tls-app-v2/main.tf
+++ b/modules/tls-app-v2/main.tf
@@ -1,0 +1,43 @@
+# For each consumed topic define an ACL for reading that topic
+resource "kafka_acl" "topic_acl" {
+  for_each            = toset(var.consume_topics)
+  resource_name       = each.value
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=${var.cert_common_name}"
+  acl_host            = var.acl_host
+  acl_operation       = "Read"
+  acl_permission_type = "Allow"
+}
+
+# For each consumed topic define an ACL for accessing the consumer group
+resource "kafka_acl" "group_acl" {
+  for_each            = toset(var.consume_groups)
+  resource_name       = each.key
+  resource_type       = "Group"
+  acl_principal       = "User:CN=${var.cert_common_name}"
+  acl_host            = var.acl_host
+  acl_operation       = "Read"
+  acl_permission_type = "Allow"
+}
+
+# For each produce topic define a write ACL for that topic
+resource "kafka_acl" "producer_acl" {
+  for_each            = toset(var.produce_topics)
+  resource_name       = each.key
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=${var.cert_common_name}"
+  acl_host            = var.acl_host
+  acl_operation       = "Write"
+  acl_permission_type = "Allow"
+}
+
+# Define a single quota for the user
+resource "kafka_quota" "quota" {
+  entity_name = "User:CN=${var.cert_common_name}"
+  entity_type = "user"
+  config = {
+    "consumer_byte_rate" = tostring(var.consumer_byte_rate)
+    "producer_byte_rate" = tostring(var.producer_byte_rate)
+    "request_percentage" = tostring(var.request_percentage)
+  }
+}

--- a/modules/tls-app-v2/provider.tf
+++ b/modules/tls-app-v2/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    kafka = {
+      source = "Mongey/kafka"
+    }
+  }
+}

--- a/modules/tls-app-v2/variables.tf
+++ b/modules/tls-app-v2/variables.tf
@@ -1,0 +1,64 @@
+variable "produce_topics" {
+  type        = list(string)
+  description = "The topics that the app produces to"
+  default     = []
+}
+
+variable "consume_topics" {
+  type        = list(string)
+  description = "The topics that the app consumes."
+  default     = []
+}
+
+variable "consume_groups" {
+  type        = list(string)
+  description = "The Kafka consumer groups that the app uses to consume."
+  default     = []
+}
+
+variable "cert_common_name" {
+  type        = string
+  description = "The principal or user/group for which the ACL is being created."
+}
+
+# ACL
+variable "acl_host" {
+  type        = string
+  description = "The host from which the principal is allowed to perform operations. Set to '*' to allow any host."
+  default     = "*"
+}
+
+# QUOTA
+variable "consumer_byte_rate" {
+  type        = number
+  description = "The maximum number of bytes per second a producer is allowed to produce to the specified entity."
+  default     = 5242880 # Limit producing to 5 MB/s
+
+  validation {
+    condition     = var.consumer_byte_rate > 0 && var.consumer_byte_rate <= 10485760
+    error_message = "Producer byte rate must be between 0 bytes per second and 10 MB per second (inclusive)."
+  }
+}
+
+variable "producer_byte_rate" {
+  type        = number
+  description = "The maximum number of bytes per second a producer is allowed to produce to the specified entity."
+  default     = 5242880 # Limit producing to 5 MB/s
+
+  validation {
+    condition     = var.producer_byte_rate > 0 && var.producer_byte_rate <= 10485760
+    error_message = "Producer byte rate must be between 0 bytes per second and 10 MB per second (inclusive)."
+  }
+}
+
+variable "request_percentage" {
+  type        = number
+  description = "The percentage of requests a specified entity is allowed to make."
+  # Allow 100% of CPU. More on this here: https://docs.confluent.io/kafka/design/quotas.html#request-rate-quotas
+  default = 100
+
+  validation {
+    condition     = var.request_percentage >= 0 && var.request_percentage <= 100
+    error_message = "Request percentage must be between 0 and 100 (inclusive)."
+  }
+}

--- a/modules/tls-app-v2/variables.tf
+++ b/modules/tls-app-v2/variables.tf
@@ -30,8 +30,9 @@ variable "acl_host" {
 
 # QUOTA
 variable "consumer_byte_rate" {
-  type        = number
-  description = "The maximum number of bytes per second a producer is allowed to produce to the specified entity."
+  type = number
+  // See https://docs.confluent.io/kafka/design/quotas.html#enforcement
+  description = "The maximum number of bytes per second consumers with the specified user can consume across topics per broker."
   default     = 5242880 # Limit producing to 5 MB/s
 
   validation {
@@ -41,8 +42,9 @@ variable "consumer_byte_rate" {
 }
 
 variable "producer_byte_rate" {
-  type        = number
-  description = "The maximum number of bytes per second a producer is allowed to produce to the specified entity."
+  type = number
+  # See https://docs.confluent.io/kafka/design/quotas.html#enforcement
+  description = "The maximum number of bytes per second producers with the specified user can produce across topics per broker."
   default     = 5242880 # Limit producing to 5 MB/s
 
   validation {
@@ -53,7 +55,7 @@ variable "producer_byte_rate" {
 
 variable "request_percentage" {
   type        = number
-  description = "The percentage of requests a specified entity is allowed to make."
+  description = "The percentage of requests the app connecting with the specified user is allowed to make."
   # Allow 100% of CPU. More on this here: https://docs.confluent.io/kafka/design/quotas.html#request-rate-quotas
   default = 100
 


### PR DESCRIPTION
See the linked ticket for details: https://linear.app/utilitywarehouse/issue/PLA2-83/tls-app-module-allow-consumer-group-for-multiple-topics

The plan is to migrate all modules one by one and after that, remove the old tls-app module and rename the tls-app-v2 to just tls-app.
