### PR TITLE
PLA2-83: tls-app fix: migrate otel dev

### DIFF
--- a/dev-aws/kafka-shared/otel/otel.tf
+++ b/dev-aws/kafka-shared/otel/otel.tf
@@ -19,13 +19,19 @@ resource "kafka_topic" "otlp_spans" {
 }
 
 module "otel_collector" {
-  source           = "../../../modules/tls-app"
+  source           = "../../../modules/tls-app-v2"
   produce_topics   = [kafka_topic.otlp_spans.name]
   cert_common_name = "otel/collector"
 }
 
 module "tempo_distributor" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.otlp_spans.name) : "processor-tempo" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.otlp_spans.name)]
+  consume_groups   = ["processor-tempo"]
   cert_common_name = "otel/tempo-distributor"
+}
+
+moved {
+  from = module.tempo_distributor.kafka_acl.group_acl["otel.otlp_spans"]
+  to   = module.tempo_distributor.kafka_acl.group_acl["processor-tempo"]
 }


### PR DESCRIPTION
Plan is clean:
```
kafka_topic.otlp_spans: Refreshing state... [id=otel.otlp_spans]
module.tempo_distributor.kafka_quota.quota: Refreshing state... [id=User:CN=otel/tempo-distributor|user]
module.tempo_distributor.kafka_acl.group_acl["processor-tempo"]: Refreshing state... [id=User:CN=otel/tempo-distributor|*|Read|Allow|Group|processor-tempo|Literal]
module.otel_collector.kafka_quota.quota: Refreshing state... [id=User:CN=otel/collector|user]
module.otel_collector.kafka_acl.producer_acl["otel.otlp_spans"]: Refreshing state... [id=User:CN=otel/collector|*|Write|Allow|Topic|otel.otlp_spans|Literal]
module.tempo_distributor.kafka_acl.topic_acl["otel.otlp_spans"]: Refreshing state... [id=User:CN=otel/tempo-distributor|*|Read|Allow|Topic|otel.otlp_spans|Literal]

Terraform will perform the following actions:

  # module.tempo_distributor.kafka_acl.group_acl["otel.otlp_spans"] has moved to module.tempo_distributor.kafka_acl.group_acl["processor-tempo"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=otel/tempo-distributor|*|Read|Allow|Group|processor-tempo|Literal"
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.
```