### PR TITLE
PLA2-83: tls-app fix: migrate dev iam

### DIFF
--- a/dev-aws/kafka-shared/iam/iam.tf
+++ b/dev-aws/kafka-shared/iam/iam.tf
@@ -15,15 +15,27 @@ resource "kafka_topic" "iam_cerbos_audit_v1" {
 }
 
 module "iam_cerbos_audit_indexer" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.iam_cerbos_audit_v1.name) : "indexer-iam-cerbos-audit-v1" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.iam_cerbos_audit_v1.name)]
+  consume_groups   = ["indexer-iam-cerbos-audit-v1"]
   cert_common_name = "auth/iam-cerbos-audit-indexer"
 }
 
+moved {
+  from = module.iam_cerbos_audit_indexer.kafka_acl.group_acl["auth.iam-cerbos-audit-v1"]
+  to   = module.iam_cerbos_audit_indexer.kafka_acl.group_acl["indexer-iam-cerbos-audit-v1"]
+}
+
 module "iam_cerbos_audit_exporter" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.iam_cerbos_audit_v1.name) : "exporter-iam-cerbos-audit-v1" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.iam_cerbos_audit_v1.name)]
+  consume_groups   = ["exporter-iam-cerbos-audit-v1"]
   cert_common_name = "auth/iam-cerbos-audit-exporter"
+}
+
+moved {
+  from = module.iam_cerbos_audit_exporter.kafka_acl.group_acl["auth.iam-cerbos-audit-v1"]
+  to   = module.iam_cerbos_audit_exporter.kafka_acl.group_acl["exporter-iam-cerbos-audit-v1"]
 }
 
 resource "kafka_topic" "iam_credentials_v1" {
@@ -43,19 +55,25 @@ resource "kafka_topic" "iam_credentials_v1" {
 }
 
 module "iam_credentials_api" {
-  source           = "../../../modules/tls-app"
+  source           = "../../../modules/tls-app-v2"
   produce_topics   = [kafka_topic.iam_credentials_v1.name]
   cert_common_name = "auth-customer/credentials-api"
 }
 
 module "iam_credentials_indexer" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.iam_credentials_v1.name) : "indexer-iam-credentials-v1" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.iam_credentials_v1.name)]
+  consume_groups   = ["indexer-iam-credentials-v1"]
   cert_common_name = "auth-customer/iam-credentials-v1-indexer"
 }
 
+moved {
+  from = module.iam_credentials_indexer.kafka_acl.group_acl["auth-customer.iam-credentials-v1"]
+  to   = module.iam_credentials_indexer.kafka_acl.group_acl["indexer-iam-credentials-v1"]
+}
+
 module "iam_customer_auth_provider" {
-  source           = "../../../modules/tls-app"
+  source           = "../../../modules/tls-app-v2"
   produce_topics   = [kafka_topic.iam_credentials_v1.name]
   cert_common_name = "clubhouse/auth-provider"
 }
@@ -77,28 +95,52 @@ resource "kafka_topic" "iam_dpd_v1" {
 }
 
 module "iam_dpd_mapper" {
-  source           = "../../../modules/tls-app"
+  source           = "../../../modules/tls-app-v2"
   produce_topics   = [kafka_topic.iam_dpd_v1.name]
-  consume_topics   = { (kafka_topic.iam_credentials_v1.name) : "iam.dpd-mapper" }
+  consume_topics   = [(kafka_topic.iam_credentials_v1.name)]
+  consume_groups   = ["iam.dpd-mapper"]
   cert_common_name = "auth-customer/dpd-mapper"
 }
 
+moved {
+  from = module.iam_dpd_mapper.kafka_acl.group_acl["auth-customer.iam-credentials-v1"]
+  to   = module.iam_dpd_mapper.kafka_acl.group_acl["iam.dpd-mapper"]
+}
+
 module "iam_dpd_di_kafka_source_customer_login_succeeded" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.iam_dpd_v1.name) : "iam.di-kafka-source-customer-login-succeeded" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.iam_dpd_v1.name)]
+  consume_groups   = ["iam.di-kafka-source-customer-login-succeeded"]
   cert_common_name = "auth-customer/di-kafka-source-customer-login-succeeded"
 }
 
+moved {
+  from = module.iam_dpd_di_kafka_source_customer_login_succeeded.kafka_acl.group_acl["auth-customer.iam-dpd-v1"]
+  to   = module.iam_dpd_di_kafka_source_customer_login_succeeded.kafka_acl.group_acl["iam.di-kafka-source-customer-login-succeeded"]
+}
+
 module "iam_dpd_di_kafka_source_customer_login_failed" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.iam_dpd_v1.name) : "iam.di-kafka-source-customer-login-failed" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.iam_dpd_v1.name)]
+  consume_groups   = ["iam.di-kafka-source-customer-login-failed"]
   cert_common_name = "auth-customer/di-kafka-source-customer-login-failed"
 }
 
+moved {
+  from = module.iam_dpd_di_kafka_source_customer_login_failed.kafka_acl.group_acl["auth-customer.iam-dpd-v1"]
+  to   = module.iam_dpd_di_kafka_source_customer_login_failed.kafka_acl.group_acl["iam.di-kafka-source-customer-login-failed"]
+}
+
 module "iam_dpd_di_kafka_source_customer_password_reset_failed" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.iam_dpd_v1.name) : "iam.di-kafka-source-customer-password-reset-failed" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.iam_dpd_v1.name)]
+  consume_groups   = ["iam.di-kafka-source-customer-password-reset-failed"]
   cert_common_name = "auth-customer/di-kafka-source-customer-password-reset-failed"
+}
+
+moved {
+  from = module.iam_dpd_di_kafka_source_customer_password_reset_failed.kafka_acl.group_acl["auth-customer.iam-dpd-v1"]
+  to   = module.iam_dpd_di_kafka_source_customer_password_reset_failed.kafka_acl.group_acl["iam.di-kafka-source-customer-password-reset-failed"]
 }
 
 resource "kafka_topic" "iam_identitydb_v1" {
@@ -119,42 +161,72 @@ resource "kafka_topic" "iam_identitydb_v1" {
 }
 
 module "iam_identitydb_indexer" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.iam_identitydb_v1.name) : "iam.identitydb-indexer" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.iam_identitydb_v1.name)]
+  consume_groups   = ["iam.identitydb-indexer"]
   cert_common_name = "auth/iam-identitydb-indexer"
 }
 
+moved {
+  from = module.iam_identitydb_indexer.kafka_acl.group_acl["auth.iam-identitydb-v1"]
+  to   = module.iam_identitydb_indexer.kafka_acl.group_acl["iam.identitydb-indexer"]
+}
+
 module "iam_jwks_publisher" {
-  source           = "../../../modules/tls-app"
+  source           = "../../../modules/tls-app-v2"
   produce_topics   = [kafka_topic.iam_identitydb_v1.name]
   cert_common_name = "auth/iam-jwks-publisher"
 }
 
 module "iam_identitydb_event_forwarder" {
-  source           = "../../../modules/tls-app"
+  source           = "../../../modules/tls-app-v2"
   produce_topics   = [kafka_topic.iam_identitydb_v1.name]
-  consume_topics   = { (kafka_topic.iam_revoked_v1.name) : "iam.identitydb-event-forwarder" }
+  consume_topics   = [(kafka_topic.iam_revoked_v1.name)]
+  consume_groups   = ["iam.identitydb-event-forwarder"]
   cert_common_name = "auth/iam-identitydb-event-forwarder"
 }
 
+moved {
+  from = module.iam_identitydb_event_forwarder.kafka_acl.group_acl["auth.iam-revoked-v1"]
+  to   = module.iam_identitydb_event_forwarder.kafka_acl.group_acl["iam.identitydb-event-forwarder"]
+}
+
 module "iam_identitydb_snapshotter" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.iam_identitydb_v1.name) : "iam-identitydb-snapshotter" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.iam_identitydb_v1.name)]
+  consume_groups   = ["iam-identitydb-snapshotter"]
   cert_common_name = "auth/iam-identitydb-snapshotter"
 }
 
+moved {
+  from = module.iam_identitydb_snapshotter.kafka_acl.group_acl["auth.iam-identitydb-v1"]
+  to   = module.iam_identitydb_snapshotter.kafka_acl.group_acl["iam-identitydb-snapshotter"]
+}
+
 module "iam_identity_api" {
-  source           = "../../../modules/tls-app"
+  source           = "../../../modules/tls-app-v2"
   produce_topics   = [kafka_topic.iam_revoked_v1.name]
-  consume_topics   = { (kafka_topic.iam_identitydb_v1.name) : "iam-identity-api" }
+  consume_topics   = [(kafka_topic.iam_identitydb_v1.name)]
+  consume_groups   = ["iam-identity-api"]
   cert_common_name = "auth/iam-identity-api"
 }
 
+moved {
+  from = module.iam_identity_api.kafka_acl.group_acl["auth.iam-identitydb-v1"]
+  to   = module.iam_identity_api.kafka_acl.group_acl["iam-identity-api"]
+}
+
 module "iam_policy_decision_api" {
-  source           = "../../../modules/tls-app"
+  source           = "../../../modules/tls-app-v2"
   cert_common_name = "auth/iam-policy-decision-api"
   produce_topics   = [kafka_topic.iam_cerbos_audit_v1.name]
-  consume_topics   = { (kafka_topic.iam_identitydb_v1.name) : "iam-policy-decision-api" }
+  consume_topics   = [(kafka_topic.iam_identitydb_v1.name)]
+  consume_groups   = ["iam-policy-decision-api"]
+}
+
+moved {
+  from = module.iam_policy_decision_api.kafka_acl.group_acl["auth.iam-identitydb-v1"]
+  to   = module.iam_policy_decision_api.kafka_acl.group_acl["iam-policy-decision-api"]
 }
 
 resource "kafka_topic" "iam_revoked_v1" {


### PR DESCRIPTION
Resources are not affected. Plan is:
```
Terraform will perform the following actions:

  # module.iam_cerbos_audit_exporter.kafka_acl.group_acl["auth.iam-cerbos-audit-v1"] has moved to module.iam_cerbos_audit_exporter.kafka_acl.group_acl["exporter-iam-cerbos-audit-v1"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth/iam-cerbos-audit-exporter|*|Read|Allow|Group|exporter-iam-cerbos-audit-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_cerbos_audit_indexer.kafka_acl.group_acl["auth.iam-cerbos-audit-v1"] has moved to module.iam_cerbos_audit_indexer.kafka_acl.group_acl["indexer-iam-cerbos-audit-v1"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth/iam-cerbos-audit-indexer|*|Read|Allow|Group|indexer-iam-cerbos-audit-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_credentials_indexer.kafka_acl.group_acl["auth-customer.iam-credentials-v1"] has moved to module.iam_credentials_indexer.kafka_acl.group_acl["indexer-iam-credentials-v1"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth-customer/iam-credentials-v1-indexer|*|Read|Allow|Group|indexer-iam-credentials-v1|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_dpd_di_kafka_source_customer_login_failed.kafka_acl.group_acl["auth-customer.iam-dpd-v1"] has moved to module.iam_dpd_di_kafka_source_customer_login_failed.kafka_acl.group_acl["iam.di-kafka-source-customer-login-failed"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth-customer/di-kafka-source-customer-login-failed|*|Read|Allow|Group|iam.di-kafka-source-customer-login-failed|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_dpd_di_kafka_source_customer_login_succeeded.kafka_acl.group_acl["auth-customer.iam-dpd-v1"] has moved to module.iam_dpd_di_kafka_source_customer_login_succeeded.kafka_acl.group_acl["iam.di-kafka-source-customer-login-succeeded"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth-customer/di-kafka-source-customer-login-succeeded|*|Read|Allow|Group|iam.di-kafka-source-customer-login-succeeded|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_dpd_di_kafka_source_customer_password_reset_failed.kafka_acl.group_acl["auth-customer.iam-dpd-v1"] has moved to module.iam_dpd_di_kafka_source_customer_password_reset_failed.kafka_acl.group_acl["iam.di-kafka-source-customer-password-reset-failed"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth-customer/di-kafka-source-customer-password-reset-failed|*|Read|Allow|Group|iam.di-kafka-source-customer-password-reset-failed|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_dpd_mapper.kafka_acl.group_acl["auth-customer.iam-credentials-v1"] has moved to module.iam_dpd_mapper.kafka_acl.group_acl["iam.dpd-mapper"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth-customer/dpd-mapper|*|Read|Allow|Group|iam.dpd-mapper|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_identity_api.kafka_acl.group_acl["auth.iam-identitydb-v1"] has moved to module.iam_identity_api.kafka_acl.group_acl["iam-identity-api"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth/iam-identity-api|*|Read|Allow|Group|iam-identity-api|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_identitydb_event_forwarder.kafka_acl.group_acl["auth.iam-revoked-v1"] has moved to module.iam_identitydb_event_forwarder.kafka_acl.group_acl["iam.identitydb-event-forwarder"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth/iam-identitydb-event-forwarder|*|Read|Allow|Group|iam.identitydb-event-forwarder|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_identitydb_indexer.kafka_acl.group_acl["auth.iam-identitydb-v1"] has moved to module.iam_identitydb_indexer.kafka_acl.group_acl["iam.identitydb-indexer"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth/iam-identitydb-indexer|*|Read|Allow|Group|iam.identitydb-indexer|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_identitydb_snapshotter.kafka_acl.group_acl["auth.iam-identitydb-v1"] has moved to module.iam_identitydb_snapshotter.kafka_acl.group_acl["iam-identitydb-snapshotter"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth/iam-identitydb-snapshotter|*|Read|Allow|Group|iam-identitydb-snapshotter|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.iam_policy_decision_api.kafka_acl.group_acl["auth.iam-identitydb-v1"] has moved to module.iam_policy_decision_api.kafka_acl.group_acl["iam-policy-decision-api"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=auth/iam-policy-decision-api|*|Read|Allow|Group|iam-policy-decision-api|Literal"
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.
```