### PR TITLE
PLA2-83: tls-app fix: migrate prod otel

### DIFF
--- a/prod-aws/kafka-shared/otel/otel.tf
+++ b/prod-aws/kafka-shared/otel/otel.tf
@@ -20,13 +20,19 @@ resource "kafka_topic" "otlp_spans" {
 }
 
 module "otel_collector" {
-  source           = "../../../modules/tls-app"
+  source           = "../../../modules/tls-app-v2"
   produce_topics   = [kafka_topic.otlp_spans.name]
   cert_common_name = "otel/collector"
 }
 
 module "tempo_distributor" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.otlp_spans.name) : "processor-tempo" }
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.otlp_spans.name)]
+  consume_groups   = ["processor-tempo"]
   cert_common_name = "otel/tempo-distributor"
+}
+
+moved {
+  from = module.tempo_distributor.kafka_acl.group_acl["otel.otlp_spans"]
+  to   = module.tempo_distributor.kafka_acl.group_acl["processor-tempo"]
 }


### PR DESCRIPTION
Plan is:
```
Terraform will perform the following actions:

  # module.tempo_distributor.kafka_acl.group_acl["otel.otlp_spans"] has moved to module.tempo_distributor.kafka_acl.group_acl["processor-tempo"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=otel/tempo-distributor|*|Read|Allow|Group|processor-tempo|Literal"
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.
```