### PR TITLE
PLA2-83: tls-app fix: migrate dev msk pubsub

### DIFF
--- a/dev-aws/kafka-shared-msk/pubsub/pubsub-examples.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/pubsub-examples.tf
@@ -17,34 +17,34 @@ resource "kafka_topic" "pubsub_examples" {
 module "example_producer" {
   source           = "../../../modules/tls-app-v2"
   produce_topics   = [kafka_topic.pubsub_examples.name]
-  cert_common_name = "dev-enablement/example-producer"
+  cert_common_name = "pubsub/example-producer"
 }
 
 module "example_process_individually_consumer" {
   source           = "../../../modules/tls-app-v2"
   consume_topics   = [(kafka_topic.pubsub_examples.name)]
-  consume_groups   = ["dev-enablement.example-consume-process-individually"]
-  cert_common_name = "dev-enablement/example-consume-process-individually"
+  consume_groups   = ["pubsub.example-consume-process-individually"]
+  cert_common_name = "pubsub/example-consume-process-individually"
 }
 
 module "example_process_batch_consumer" {
   source           = "../../../modules/tls-app-v2"
   consume_topics   = [(kafka_topic.pubsub_examples.name)]
-  consume_groups   = ["dev-enablement.example-consume-process-batch"]
-  cert_common_name = "dev-enablement/example-consume-process-batch"
+  consume_groups   = ["pubsub.example-consume-process-batch"]
+  cert_common_name = "pubsub/example-consume-process-batch"
 }
 
 moved {
-  from = module.example_process_individually_consumer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
-  to   = module.example_process_individually_consumer.kafka_acl.group_acl["dev-enablement.example-consume-process-individually"]
+  from = module.example_process_individually_consumer.kafka_acl.group_acl["pubsub.examples"]
+  to   = module.example_process_individually_consumer.kafka_acl.group_acl["pubsub.example-consume-process-individually"]
 }
 
 moved {
-  from = module.example_process_batch_consumer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
-  to   = module.example_process_batch_consumer.kafka_acl.group_acl["dev-enablement.example-consume-process-batch"]
+  from = module.example_process_batch_consumer.kafka_acl.group_acl["pubsub.examples"]
+  to   = module.example_process_batch_consumer.kafka_acl.group_acl["pubsub.example-consume-process-batch"]
 }
 
 moved {
-  from = module.es_topic_indexer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
-  to   = module.es_topic_indexer.kafka_acl.group_acl["dev-enablement.es-topic-indexer"]
+  from = module.es_topic_indexer.kafka_acl.group_acl["pubsub.pubsub-examples"]
+  to   = module.es_topic_indexer.kafka_acl.group_acl["pubsub.es-topic-indexer"]
 }

--- a/dev-aws/kafka-shared-msk/pubsub/pubsub-examples.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/pubsub-examples.tf
@@ -15,19 +15,36 @@ resource "kafka_topic" "pubsub_examples" {
 }
 
 module "example_producer" {
-  source           = "../../../modules/tls-app"
+  source           = "../../../modules/tls-app-v2"
   produce_topics   = [kafka_topic.pubsub_examples.name]
-  cert_common_name = "pubsub/example-producer"
+  cert_common_name = "dev-enablement/example-producer"
 }
 
 module "example_process_individually_consumer" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.pubsub_examples.name) : "pubsub.example-consume-process-individually" }
-  cert_common_name = "pubsub/example-consume-process-individually"
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.pubsub_examples.name)]
+  consume_groups   = ["dev-enablement.example-consume-process-individually"]
+  cert_common_name = "dev-enablement/example-consume-process-individually"
 }
 
 module "example_process_batch_consumer" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = { (kafka_topic.pubsub_examples.name) : "pubsub.example-consume-process-batch" }
-  cert_common_name = "pubsub/example-consume-process-batch"
+  source           = "../../../modules/tls-app-v2"
+  consume_topics   = [(kafka_topic.pubsub_examples.name)]
+  consume_groups   = ["dev-enablement.example-consume-process-batch"]
+  cert_common_name = "dev-enablement/example-consume-process-batch"
+}
+
+moved {
+  from = module.example_process_individually_consumer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
+  to   = module.example_process_individually_consumer.kafka_acl.group_acl["dev-enablement.example-consume-process-individually"]
+}
+
+moved {
+  from = module.example_process_batch_consumer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
+  to   = module.example_process_batch_consumer.kafka_acl.group_acl["dev-enablement.example-consume-process-batch"]
+}
+
+moved {
+  from = module.es_topic_indexer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
+  to   = module.es_topic_indexer.kafka_acl.group_acl["dev-enablement.es-topic-indexer"]
 }


### PR DESCRIPTION
Plan is clean:
```
Terraform will perform the following actions:

  # module.example_process_batch_consumer.kafka_acl.group_acl["pubsub.examples"] has moved to module.example_process_batch_consumer.kafka_acl.group_acl["pubsub.example-consume-process-batch"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=pubsub/example-consume-process-batch|*|Read|Allow|Group|pubsub.example-consume-process-batch|Literal"
        # (7 unchanged attributes hidden)
    }

  # module.example_process_individually_consumer.kafka_acl.group_acl["pubsub.examples"] has moved to module.example_process_individually_consumer.kafka_acl.group_acl["pubsub.example-consume-process-individually"]
    resource "kafka_acl" "group_acl" {
        id                           = "User:CN=pubsub/example-consume-process-individually|*|Read|Allow|Group|pubsub.example-consume-process-individually|Literal"
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.
```