### PR TITLE
PLA2-83: tls-app fix: remove the "moved" blocks

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -64,17 +64,6 @@ module "budget_plan_fabricator" {
   cert_common_name = "energy-budget-plan/eqdb-fabricator"
 }
 
-moved {
-  from = module.budget_plan_fabricator.kafka_acl.group_acl["energy-budget-plan.eqdb-loader"]
-  to   = module.budget_plan_fabricator.kafka_acl.group_acl["energy-budget-plan.eqdb-fabricator-loader-v1"]
-}
-
-moved {
-  from = module.budget_plan_fabricator.kafka_acl.group_acl["energy-budget-plan.customer-change"]
-  to   = module.budget_plan_fabricator.kafka_acl.group_acl["energy-budget-plan.eqdb-fabricator-customer-change-v1"]
-}
-
-
 module "budget_plan_calculator" {
   source           = "../../../modules/tls-app"
   consume_topics   = [(kafka_topic.budget_plan.name)]
@@ -83,7 +72,3 @@ module "budget_plan_calculator" {
   cert_common_name = "energy-budget-plan/calculator"
 }
 
-moved {
-  from = module.budget_plan_calculator.kafka_acl.group_acl["energy-budget-plan.budget-plan"]
-  to   = module.budget_plan_calculator.kafka_acl.group_acl["energy-budget-plan.calculator-v1"]
-}

--- a/dev-aws/kafka-shared-msk/pubsub/pubsub-examples.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/pubsub-examples.tf
@@ -34,17 +34,3 @@ module "example_process_batch_consumer" {
   cert_common_name = "pubsub/example-consume-process-batch"
 }
 
-moved {
-  from = module.example_process_individually_consumer.kafka_acl.group_acl["pubsub.examples"]
-  to   = module.example_process_individually_consumer.kafka_acl.group_acl["pubsub.example-consume-process-individually"]
-}
-
-moved {
-  from = module.example_process_batch_consumer.kafka_acl.group_acl["pubsub.examples"]
-  to   = module.example_process_batch_consumer.kafka_acl.group_acl["pubsub.example-consume-process-batch"]
-}
-
-moved {
-  from = module.es_topic_indexer.kafka_acl.group_acl["pubsub.pubsub-examples"]
-  to   = module.es_topic_indexer.kafka_acl.group_acl["pubsub.es-topic-indexer"]
-}

--- a/dev-aws/kafka-shared/customer-billing/customer-billing.tf
+++ b/dev-aws/kafka-shared/customer-billing/customer-billing.tf
@@ -46,12 +46,3 @@ module "billing_fulfilment_public_events_translator" {
   consume_groups   = ["bex.billing-fulfilment-public-events-translator"]
 }
 
-moved {
-  from = module.bills_total_api.kafka_acl.group_acl["bex.internal.bill_fulfilled"]
-  to   = module.bills_total_api.kafka_acl.group_acl["bex.bills-total-api-reader"]
-}
-
-moved {
-  from = module.billing_fulfilment_public_events_translator.kafka_acl.group_acl["bex.internal.bill_fulfilled"]
-  to   = module.billing_fulfilment_public_events_translator.kafka_acl.group_acl["bex.billing-fulfilment-public-events-translator"]
-}

--- a/dev-aws/kafka-shared/dev-enablement/pubsub-examples.tf
+++ b/dev-aws/kafka-shared/dev-enablement/pubsub-examples.tf
@@ -40,18 +40,3 @@ module "es_topic_indexer" {
   consume_groups   = ["dev-enablement.es-topic-indexer"]
   cert_common_name = "dev-enablement/es-topic-indexer"
 }
-
-moved {
-  from = module.example_process_individually_consumer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
-  to   = module.example_process_individually_consumer.kafka_acl.group_acl["dev-enablement.example-consume-process-individually"]
-}
-
-moved {
-  from = module.example_process_batch_consumer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
-  to   = module.example_process_batch_consumer.kafka_acl.group_acl["dev-enablement.example-consume-process-batch"]
-}
-
-moved {
-  from = module.es_topic_indexer.kafka_acl.group_acl["dev-enablement.pubsub-examples"]
-  to   = module.es_topic_indexer.kafka_acl.group_acl["dev-enablement.es-topic-indexer"]
-}

--- a/dev-aws/kafka-shared/iam/iam.tf
+++ b/dev-aws/kafka-shared/iam/iam.tf
@@ -21,21 +21,11 @@ module "iam_cerbos_audit_indexer" {
   cert_common_name = "auth/iam-cerbos-audit-indexer"
 }
 
-moved {
-  from = module.iam_cerbos_audit_indexer.kafka_acl.group_acl["auth.iam-cerbos-audit-v1"]
-  to   = module.iam_cerbos_audit_indexer.kafka_acl.group_acl["indexer-iam-cerbos-audit-v1"]
-}
-
 module "iam_cerbos_audit_exporter" {
   source           = "../../../modules/tls-app"
   consume_topics   = [(kafka_topic.iam_cerbos_audit_v1.name)]
   consume_groups   = ["exporter-iam-cerbos-audit-v1"]
   cert_common_name = "auth/iam-cerbos-audit-exporter"
-}
-
-moved {
-  from = module.iam_cerbos_audit_exporter.kafka_acl.group_acl["auth.iam-cerbos-audit-v1"]
-  to   = module.iam_cerbos_audit_exporter.kafka_acl.group_acl["exporter-iam-cerbos-audit-v1"]
 }
 
 resource "kafka_topic" "iam_credentials_v1" {
@@ -65,11 +55,6 @@ module "iam_credentials_indexer" {
   consume_topics   = [(kafka_topic.iam_credentials_v1.name)]
   consume_groups   = ["indexer-iam-credentials-v1"]
   cert_common_name = "auth-customer/iam-credentials-v1-indexer"
-}
-
-moved {
-  from = module.iam_credentials_indexer.kafka_acl.group_acl["auth-customer.iam-credentials-v1"]
-  to   = module.iam_credentials_indexer.kafka_acl.group_acl["indexer-iam-credentials-v1"]
 }
 
 module "iam_customer_auth_provider" {
@@ -102,21 +87,11 @@ module "iam_dpd_mapper" {
   cert_common_name = "auth-customer/dpd-mapper"
 }
 
-moved {
-  from = module.iam_dpd_mapper.kafka_acl.group_acl["auth-customer.iam-credentials-v1"]
-  to   = module.iam_dpd_mapper.kafka_acl.group_acl["iam.dpd-mapper"]
-}
-
 module "iam_dpd_di_kafka_source_customer_login_succeeded" {
   source           = "../../../modules/tls-app"
   consume_topics   = [(kafka_topic.iam_dpd_v1.name)]
   consume_groups   = ["iam.di-kafka-source-customer-login-succeeded"]
   cert_common_name = "auth-customer/di-kafka-source-customer-login-succeeded"
-}
-
-moved {
-  from = module.iam_dpd_di_kafka_source_customer_login_succeeded.kafka_acl.group_acl["auth-customer.iam-dpd-v1"]
-  to   = module.iam_dpd_di_kafka_source_customer_login_succeeded.kafka_acl.group_acl["iam.di-kafka-source-customer-login-succeeded"]
 }
 
 module "iam_dpd_di_kafka_source_customer_login_failed" {
@@ -126,21 +101,11 @@ module "iam_dpd_di_kafka_source_customer_login_failed" {
   cert_common_name = "auth-customer/di-kafka-source-customer-login-failed"
 }
 
-moved {
-  from = module.iam_dpd_di_kafka_source_customer_login_failed.kafka_acl.group_acl["auth-customer.iam-dpd-v1"]
-  to   = module.iam_dpd_di_kafka_source_customer_login_failed.kafka_acl.group_acl["iam.di-kafka-source-customer-login-failed"]
-}
-
 module "iam_dpd_di_kafka_source_customer_password_reset_failed" {
   source           = "../../../modules/tls-app"
   consume_topics   = [(kafka_topic.iam_dpd_v1.name)]
   consume_groups   = ["iam.di-kafka-source-customer-password-reset-failed"]
   cert_common_name = "auth-customer/di-kafka-source-customer-password-reset-failed"
-}
-
-moved {
-  from = module.iam_dpd_di_kafka_source_customer_password_reset_failed.kafka_acl.group_acl["auth-customer.iam-dpd-v1"]
-  to   = module.iam_dpd_di_kafka_source_customer_password_reset_failed.kafka_acl.group_acl["iam.di-kafka-source-customer-password-reset-failed"]
 }
 
 resource "kafka_topic" "iam_identitydb_v1" {
@@ -167,11 +132,6 @@ module "iam_identitydb_indexer" {
   cert_common_name = "auth/iam-identitydb-indexer"
 }
 
-moved {
-  from = module.iam_identitydb_indexer.kafka_acl.group_acl["auth.iam-identitydb-v1"]
-  to   = module.iam_identitydb_indexer.kafka_acl.group_acl["iam.identitydb-indexer"]
-}
-
 module "iam_jwks_publisher" {
   source           = "../../../modules/tls-app"
   produce_topics   = [kafka_topic.iam_identitydb_v1.name]
@@ -186,21 +146,11 @@ module "iam_identitydb_event_forwarder" {
   cert_common_name = "auth/iam-identitydb-event-forwarder"
 }
 
-moved {
-  from = module.iam_identitydb_event_forwarder.kafka_acl.group_acl["auth.iam-revoked-v1"]
-  to   = module.iam_identitydb_event_forwarder.kafka_acl.group_acl["iam.identitydb-event-forwarder"]
-}
-
 module "iam_identitydb_snapshotter" {
   source           = "../../../modules/tls-app"
   consume_topics   = [(kafka_topic.iam_identitydb_v1.name)]
   consume_groups   = ["iam-identitydb-snapshotter"]
   cert_common_name = "auth/iam-identitydb-snapshotter"
-}
-
-moved {
-  from = module.iam_identitydb_snapshotter.kafka_acl.group_acl["auth.iam-identitydb-v1"]
-  to   = module.iam_identitydb_snapshotter.kafka_acl.group_acl["iam-identitydb-snapshotter"]
 }
 
 module "iam_identity_api" {
@@ -211,22 +161,12 @@ module "iam_identity_api" {
   cert_common_name = "auth/iam-identity-api"
 }
 
-moved {
-  from = module.iam_identity_api.kafka_acl.group_acl["auth.iam-identitydb-v1"]
-  to   = module.iam_identity_api.kafka_acl.group_acl["iam-identity-api"]
-}
-
 module "iam_policy_decision_api" {
   source           = "../../../modules/tls-app"
   cert_common_name = "auth/iam-policy-decision-api"
   produce_topics   = [kafka_topic.iam_cerbos_audit_v1.name]
   consume_topics   = [(kafka_topic.iam_identitydb_v1.name)]
   consume_groups   = ["iam-policy-decision-api"]
-}
-
-moved {
-  from = module.iam_policy_decision_api.kafka_acl.group_acl["auth.iam-identitydb-v1"]
-  to   = module.iam_policy_decision_api.kafka_acl.group_acl["iam-policy-decision-api"]
 }
 
 resource "kafka_topic" "iam_revoked_v1" {

--- a/dev-aws/kafka-shared/otel/otel.tf
+++ b/dev-aws/kafka-shared/otel/otel.tf
@@ -31,7 +31,3 @@ module "tempo_distributor" {
   cert_common_name = "otel/tempo-distributor"
 }
 
-moved {
-  from = module.tempo_distributor.kafka_acl.group_acl["otel.otlp_spans"]
-  to   = module.tempo_distributor.kafka_acl.group_acl["processor-tempo"]
-}

--- a/prod-aws/kafka-shared/customer-billing/customer-billing.tf
+++ b/prod-aws/kafka-shared/customer-billing/customer-billing.tf
@@ -46,12 +46,3 @@ module "billing_fulfilment_public_events_translator" {
   consume_groups   = ["bex.billing-fulfilment-public-events-translator"]
 }
 
-moved {
-  from = module.bills_total_api.kafka_acl.group_acl["bex.internal.bill_fulfilled"]
-  to   = module.bills_total_api.kafka_acl.group_acl["bex.bills-total-api-reader"]
-}
-
-moved {
-  from = module.billing_fulfilment_public_events_translator.kafka_acl.group_acl["bex.internal.bill_fulfilled"]
-  to   = module.billing_fulfilment_public_events_translator.kafka_acl.group_acl["bex.billing-fulfilment-public-events-translator"]
-}

--- a/prod-aws/kafka-shared/iam/iam.tf
+++ b/prod-aws/kafka-shared/iam/iam.tf
@@ -21,21 +21,11 @@ module "iam_cerbos_audit_indexer" {
   cert_common_name = "auth/iam-cerbos-audit-indexer"
 }
 
-moved {
-  from = module.iam_cerbos_audit_indexer.kafka_acl.group_acl["auth.iam-cerbos-audit-v1"]
-  to   = module.iam_cerbos_audit_indexer.kafka_acl.group_acl["indexer-iam-cerbos-audit-v1"]
-}
-
 module "iam_cerbos_audit_exporter" {
   source           = "../../../modules/tls-app"
   consume_topics   = [(kafka_topic.iam_cerbos_audit_v1.name)]
   consume_groups   = ["exporter-iam-cerbos-audit-v1"]
   cert_common_name = "auth/iam-cerbos-audit-exporter"
-}
-
-moved {
-  from = module.iam_cerbos_audit_exporter.kafka_acl.group_acl["auth.iam-cerbos-audit-v1"]
-  to   = module.iam_cerbos_audit_exporter.kafka_acl.group_acl["exporter-iam-cerbos-audit-v1"]
 }
 
 resource "kafka_topic" "iam_credentials_v1" {
@@ -65,11 +55,6 @@ module "iam_credentials_indexer" {
   consume_topics   = [(kafka_topic.iam_credentials_v1.name)]
   consume_groups   = ["indexer-iam-credentials-v1"]
   cert_common_name = "auth-customer/iam-credentials-v1-indexer"
-}
-
-moved {
-  from = module.iam_credentials_indexer.kafka_acl.group_acl["auth-customer.iam-credentials-v1"]
-  to   = module.iam_credentials_indexer.kafka_acl.group_acl["indexer-iam-credentials-v1"]
 }
 
 module "iam_customer_auth_provider" {
@@ -102,21 +87,11 @@ module "iam_dpd_mapper" {
   cert_common_name = "auth-customer/dpd-mapper"
 }
 
-moved {
-  from = module.iam_dpd_mapper.kafka_acl.group_acl["auth-customer.iam-credentials-v1"]
-  to   = module.iam_dpd_mapper.kafka_acl.group_acl["iam.dpd-mapper"]
-}
-
 module "iam_dpd_di_kafka_source_customer_login_succeeded" {
   source           = "../../../modules/tls-app"
   consume_topics   = [(kafka_topic.iam_dpd_v1.name)]
   consume_groups   = ["iam.di-kafka-source-customer-login-succeeded"]
   cert_common_name = "auth-customer/di-kafka-source-customer-login-succeeded"
-}
-
-moved {
-  from = module.iam_dpd_di_kafka_source_customer_login_succeeded.kafka_acl.group_acl["auth-customer.iam-dpd-v1"]
-  to   = module.iam_dpd_di_kafka_source_customer_login_succeeded.kafka_acl.group_acl["iam.di-kafka-source-customer-login-succeeded"]
 }
 
 module "iam_dpd_di_kafka_source_customer_login_failed" {
@@ -126,21 +101,11 @@ module "iam_dpd_di_kafka_source_customer_login_failed" {
   cert_common_name = "auth-customer/di-kafka-source-customer-login-failed"
 }
 
-moved {
-  from = module.iam_dpd_di_kafka_source_customer_login_failed.kafka_acl.group_acl["auth-customer.iam-dpd-v1"]
-  to   = module.iam_dpd_di_kafka_source_customer_login_failed.kafka_acl.group_acl["iam.di-kafka-source-customer-login-failed"]
-}
-
 module "iam_dpd_di_kafka_source_customer_password_reset_failed" {
   source           = "../../../modules/tls-app"
   consume_topics   = [(kafka_topic.iam_dpd_v1.name)]
   consume_groups   = ["iam.di-kafka-source-customer-password-reset-failed"]
   cert_common_name = "auth-customer/di-kafka-source-customer-password-reset-failed"
-}
-
-moved {
-  from = module.iam_dpd_di_kafka_source_customer_password_reset_failed.kafka_acl.group_acl["auth-customer.iam-dpd-v1"]
-  to   = module.iam_dpd_di_kafka_source_customer_password_reset_failed.kafka_acl.group_acl["iam.di-kafka-source-customer-password-reset-failed"]
 }
 
 resource "kafka_topic" "iam_identitydb_v1" {
@@ -167,11 +132,6 @@ module "iam_identitydb_indexer" {
   cert_common_name = "auth/iam-identitydb-indexer"
 }
 
-moved {
-  from = module.iam_identitydb_indexer.kafka_acl.group_acl["auth.iam-identitydb-v1"]
-  to   = module.iam_identitydb_indexer.kafka_acl.group_acl["iam.identitydb-indexer"]
-}
-
 module "iam_jwks_publisher" {
   source           = "../../../modules/tls-app"
   produce_topics   = [kafka_topic.iam_identitydb_v1.name]
@@ -186,21 +146,11 @@ module "iam_identitydb_event_forwarder" {
   cert_common_name = "auth/iam-identitydb-event-forwarder"
 }
 
-moved {
-  from = module.iam_identitydb_event_forwarder.kafka_acl.group_acl["auth.iam-revoked-v1"]
-  to   = module.iam_identitydb_event_forwarder.kafka_acl.group_acl["iam.identitydb-event-forwarder"]
-}
-
 module "iam_identitydb_snapshotter" {
   source           = "../../../modules/tls-app"
   consume_topics   = [(kafka_topic.iam_identitydb_v1.name)]
   consume_groups   = ["iam-identitydb-snapshotter"]
   cert_common_name = "auth/iam-identitydb-snapshotter"
-}
-
-moved {
-  from = module.iam_identitydb_snapshotter.kafka_acl.group_acl["auth.iam-identitydb-v1"]
-  to   = module.iam_identitydb_snapshotter.kafka_acl.group_acl["iam-identitydb-snapshotter"]
 }
 
 module "iam_identity_api" {
@@ -211,22 +161,12 @@ module "iam_identity_api" {
   cert_common_name = "auth/iam-identity-api"
 }
 
-moved {
-  from = module.iam_identity_api.kafka_acl.group_acl["auth.iam-identitydb-v1"]
-  to   = module.iam_identity_api.kafka_acl.group_acl["iam-identity-api"]
-}
-
 module "iam_policy_decision_api" {
   source           = "../../../modules/tls-app"
   cert_common_name = "auth/iam-policy-decision-api"
   produce_topics   = [kafka_topic.iam_cerbos_audit_v1.name]
   consume_topics   = [(kafka_topic.iam_identitydb_v1.name)]
   consume_groups   = ["iam-policy-decision-api"]
-}
-
-moved {
-  from = module.iam_policy_decision_api.kafka_acl.group_acl["auth.iam-identitydb-v1"]
-  to   = module.iam_policy_decision_api.kafka_acl.group_acl["iam-policy-decision-api"]
 }
 
 resource "kafka_topic" "iam_revoked_v1" {

--- a/prod-aws/kafka-shared/otel/otel.tf
+++ b/prod-aws/kafka-shared/otel/otel.tf
@@ -32,7 +32,3 @@ module "tempo_distributor" {
   cert_common_name = "otel/tempo-distributor"
 }
 
-moved {
-  from = module.tempo_distributor.kafka_acl.group_acl["otel.otlp_spans"]
-  to   = module.tempo_distributor.kafka_acl.group_acl["processor-tempo"]
-}


### PR DESCRIPTION
The "moved" blocks are no longer necessary, as all modules were applied.
No resource will be affected.

Tested on dev-aws `iam` and got on plan:
```
No changes. Your infrastructure matches the configuration.
```