### PR TITLE
PLA2-86: tls-app: fix quota definition

### DIFF
--- a/modules/tls-app/main.tf
+++ b/modules/tls-app/main.tf
@@ -33,7 +33,7 @@ resource "kafka_acl" "producer_acl" {
 
 # Define a single quota for the user
 resource "kafka_quota" "quota" {
-  entity_name = "User:CN=${var.cert_common_name}"
+  entity_name = "CN=${var.cert_common_name}"
   entity_type = "user"
   config = {
     "consumer_byte_rate" = tostring(var.consumer_byte_rate)


### PR DESCRIPTION
Quota was not enforced, as the entity name shouldn't contain the "User:" prefix.
Tested without the prefix and now it is ok.