### PR TITLE
[BEX-482] increase the message size on the topic

### DIFF
--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -146,8 +146,8 @@ resource "kafka_topic" "replicated-billing-engine-events" {
     "compression.type" = "zstd"
     "retention.bytes"  = "-1"
     "retention.ms"     = "-1"
-    # allow max 1MB for a message
-    "max.message.bytes" = "1048588"
+    # allow max 10MB for a message
+    "max.message.bytes" = "10485880"
     "cleanup.policy"    = "delete"
   }
 }


### PR DESCRIPTION
We have changed the configuration in topics to have more reasonable sizes. The `replicated-billing-engine-events` topic was configured to 1MB because we didn't expect any messages larger than that. The MM stopped (silently; errors in logs) replicating that topic.

I used the redpanda UI to identify the offending message, the copied message was (when stored as JSON) 7.9MB - this includes some metadata but is mainly the raw payload. 

This PR increases the message size for that topic to 10MB 