### PR TITLE
[BEX-482] kafka prod increase message size

### DIFF
--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -146,8 +146,8 @@ resource "kafka_topic" "replicated-billing-engine-events" {
     "compression.type" = "zstd"
     "retention.bytes"  = "-1"
     "retention.ms"     = "-1"
-    # allow max 1MB for a message
-    "max.message.bytes" = "1048588"
+    # allow max 10MB for a message
+    "max.message.bytes" = "10485880"
     "cleanup.policy"    = "delete"
   }
 }

--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -146,8 +146,8 @@ resource "kafka_topic" "replicated-billing-engine-events" {
     "compression.type" = "zstd"
     "retention.bytes"  = "-1"
     "retention.ms"     = "-1"
-    # allow max 10MB for a message
-    "max.message.bytes" = "10485880"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
     "cleanup.policy"    = "delete"
   }
 }


### PR DESCRIPTION
MM failed again with:

```
org.apache.kafka.common.errors.RecordTooLargeException: The request included a message larger than the max message size the server will accept.

[2024-03-19 13:10:59,203] ERROR [MirrorSourceConnector|task-3] WorkerSourceTask{id=MirrorSourceConnector-3} failed to send record to replicated-billing-engine-events:  (org.apache.kafka.connect.runtime.AbstractWorkerSourceTask:415)
```

Increase message size again by factor 10