### PR TITLE
[BEX] remove non bex topics

### DIFF
--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -82,20 +82,6 @@ resource "kafka_topic" "invoice-redelivery-rejections" {
   }
 }
 
-resource "kafka_topic" "invoice-diffs" {
-  name               = "invoice-diffs"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
-    # allow max 1MB for a message
-    "max.message.bytes" = "1048588"
-    "cleanup.policy"    = "delete"
-  }
-}
-
 resource "kafka_topic" "public-fulfilment-events" {
   name               = "public-fulfilment-events"
   replication_factor = 3
@@ -104,34 +90,6 @@ resource "kafka_topic" "public-fulfilment-events" {
     "compression.type" = "zstd"
     "retention.bytes"  = "-1"
     "retention.ms"     = "-1"
-    # allow max 1MB for a message
-    "max.message.bytes" = "1048588"
-    "cleanup.policy"    = "delete"
-  }
-}
-
-resource "kafka_topic" "dummy-bill-extracts-historic-model" {
-  name               = "dummy-bill-extracts-historic-model"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
-    # allow max 100MB for a message
-    "max.message.bytes" = "104857600"
-    "cleanup.policy"    = "delete"
-  }
-}
-
-resource "kafka_topic" "dummy-bill-core-model" {
-  name               = "dummy-bill-core-model"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
     # allow max 1MB for a message
     "max.message.bytes" = "1048588"
     "cleanup.policy"    = "delete"
@@ -194,50 +152,8 @@ resource "kafka_topic" "replicated-bill-extracts-historic-model" {
   }
 }
 
-resource "kafka_topic" "budget-plan" {
-  name               = "budget-plan"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
-    # allow max 100MB for a message
-    "max.message.bytes" = "104857600"
-    "cleanup.policy"    = "delete"
-  }
-}
-
-resource "kafka_topic" "assessment-requests" {
-  name               = "assessment-requests"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
-    # allow max 1MB for a message
-    "max.message.bytes" = "1048588"
-    "cleanup.policy"    = "delete"
-  }
-}
-
 resource "kafka_topic" "customer-change" {
   name               = "customer-change"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
-    # allow max 1MB for a message
-    "max.message.bytes" = "1048588"
-    "cleanup.policy"    = "delete"
-  }
-}
-
-resource "kafka_topic" "eqdb-loader" {
-  name               = "eqdb-loader"
   replication_factor = 3
   partitions         = 10
   config = {
@@ -292,76 +208,6 @@ resource "kafka_topic" "account-balance-change-deadletter" {
   }
 }
 
-resource "kafka_topic" "budget-plan-calculation-deadletter" {
-  name               = "budget-plan-calculation-deadletter"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
-    # allow max 100MB for a message
-    "max.message.bytes" = "104857600"
-    "cleanup.policy"    = "delete"
-  }
-}
-
-resource "kafka_topic" "budget-plan-fabrication-deadletter" {
-  name               = "budget-plan-fabrication-deadletter"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
-    # allow max 100MB for a message
-    "max.message.bytes" = "104857600"
-    "cleanup.policy"    = "delete"
-  }
-}
-
-resource "kafka_topic" "budget-plan-change-notification-failures" {
-  name               = "budget-plan-change-notification-failures"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
-    # allow max 100MB for a message
-    "max.message.bytes" = "104857600"
-    "cleanup.policy"    = "delete"
-  }
-}
-
-resource "kafka_topic" "budget-plan-change-notification-deliveries" {
-  name               = "budget-plan-change-notification-deliveries"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
-    # allow max 100MB for a message
-    "max.message.bytes" = "104857600"
-    "cleanup.policy"    = "delete"
-  }
-}
-
-resource "kafka_topic" "bill-budget-plan-proximo-reader-deadletter" {
-  name               = "bill-budget-plan-proximo-reader-deadletter"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
-    # allow max 100MB for a message
-    "max.message.bytes" = "104857600"
-    "cleanup.policy"    = "delete"
-  }
-}
-
 resource "kafka_topic" "billing-comms-preferences-events" {
   name               = "billing-comms-preferences-events"
   replication_factor = 3
@@ -392,20 +238,6 @@ resource "kafka_topic" "deadletter-billing-comms-preferences-events" {
 
 resource "kafka_topic" "account-payment-details_v1" {
   name               = "account-payment-details.v1"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    # retain 8GB on each partition
-    "retention.bytes" = "8053063680"
-    # allow max 1MB for a message
-    "max.message.bytes" = "1048588"
-    "cleanup.policy"    = "delete"
-  }
-}
-
-resource "kafka_topic" "dummy-placeholder" {
-  name               = "dummy-placeholder"
   replication_factor = 3
   partitions         = 10
   config = {


### PR DESCRIPTION
We have to migrate topic by topic because MM failed to run with all topics and consumer groups configured. This removes topics that aren't used by BEX as well as `invoice-diffs` that is not referenced anywhere and dummy topics. I will change the services that use the dummy topic so that the topic can be omitted