### PR TITLE
[BEX] remove replicated-bill-core-model

### DIFF
--- a/dev-aws/customer-billing/topics.tf
+++ b/dev-aws/customer-billing/topics.tf
@@ -166,20 +166,6 @@ resource "kafka_topic" "replicated-internal-bill-core-model" {
   }
 }
 
-resource "kafka_topic" "replicated-bill-core-model" {
-  name               = "replicated-bill-core-model"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    "retention.bytes"  = "-1"
-    "retention.ms"     = "-1"
-    # allow max 100MB for a message
-    "max.message.bytes" = "104857600"
-    "cleanup.policy"    = "delete"
-  }
-}
-
 resource "kafka_topic" "replicated-bill-extracts-historic-model" {
   name               = "replicated-bill-extracts-historic-model"
   replication_factor = 3

--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -124,20 +124,6 @@ resource "kafka_topic" "replicated-internal-bill-core-model" {
   }
 }
 
-resource "kafka_topic" "replicated-bill-core-model" {
-  name               = "replicated-bill-core-model"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "compression.type" = "zstd"
-    "retention.bytes"  = "-1"
-    "retention.ms"     = "-1"
-    # allow max 100MB for a message
-    "max.message.bytes" = "104857600"
-    "cleanup.policy"    = "delete"
-  }
-}
-
 resource "kafka_topic" "replicated-bill-extracts-historic-model" {
   name               = "replicated-bill-extracts-historic-model"
   replication_factor = 3


### PR DESCRIPTION
`replicated-bill-core-model` and `replicated-internal-bill-core-model` both contain the same event and both had 1 consumer. The consumer on `replicated-bill-core-model` will consume from `replicated-internal-bill-core-model`