### PR TITLE
create new topic to forward password management events

### DIFF
--- a/dev-aws/kafka-shared/iam/iam.tf
+++ b/dev-aws/kafka-shared/iam/iam.tf
@@ -235,8 +235,8 @@ resource "kafka_topic" "iam_revoked_v1" {
 }
 
 
-resource "kafka_topic" "iam_credentials_public_events_mapper_v1" {
-    name = "auth-customer.credentials-public-events-mapper-v1"
+resource "kafka_topic" "iam_credentials_v1_public" {
+    name = "auth-customer.iam-credentials-v1-public"
     replication_factor = 3
     parititions = 10
     config = {
@@ -251,10 +251,10 @@ resource "kafka_topic" "iam_credentials_public_events_mapper_v1" {
     }
 }
 
-module "iam_password_change_processor" {
+module "iam_credentials_public_events_mapper" {
     source  = "../../../modules/tls-app"
     cert_comon_name= "auth-customer/credentials-public-events-mapper"
-    produce_topics = [kafka_topic.iam_credentials_public_events_mapper_v1.name]
+    produce_topics = [kafka_topic.iam_credentials_v1_public.name]
     consume_topics = [(kafka_topic.iam_credentials_v1)]
-    consume_groups = ["iam.password-change-forwarder"]
+    consume_groups = ["iam.public-events-mapper-iam-credentials_v1"]
 }

--- a/dev-aws/kafka-shared/iam/iam.tf
+++ b/dev-aws/kafka-shared/iam/iam.tf
@@ -235,10 +235,10 @@ resource "kafka_topic" "iam_revoked_v1" {
 }
 
 
-resource "kafka_topic" "iam_password_change_forwarder_v1" {
-    name = "auth.iam-password-change-forwarder-v1"
+resource "kafka_topic" "iam_credentials_public_events_mapper_v1" {
+    name = "auth-customer.credentials-public-events-mapper-v1"
     replication_factor = 3
-    parititions = 1
+    parititions = 10
     config = {
         # retain 100MB on each partition
         "retention.bytes" = "104857600"
@@ -252,9 +252,9 @@ resource "kafka_topic" "iam_password_change_forwarder_v1" {
 }
 
 module "iam_password_change_processor" {
-    source  = "../../../mmodules/tls-app"
-    cert_comon_name= "auth-customer/password-change-processor"
-    produce_topics = [kafka_topic.iam_password_change_forwarder_v1.name]
+    source  = "../../../modules/tls-app"
+    cert_comon_name= "auth-customer/credentials-public-events-mapper"
+    produce_topics = [kafka_topic.iam_credentials_public_events_mapper_v1.name]
     consume_topics = [(kafka_topic.iam_credentials_v1)]
     consume_groups = ["iam.password-change-forwarder"]
 }

--- a/dev-aws/kafka-shared/iam/iam.tf
+++ b/dev-aws/kafka-shared/iam/iam.tf
@@ -236,25 +236,25 @@ resource "kafka_topic" "iam_revoked_v1" {
 
 
 resource "kafka_topic" "iam_credentials_v1_public" {
-    name = "auth-customer.iam-credentials-v1-public"
-    replication_factor = 3
-    parititions = 10
-    config = {
-        # retain 100MB on each partition
-        "retention.bytes" = "104857600"
-        # keep data for 7 days
-        "retention.ms" = "604800000"
-        # allow max 1 MB for a message
-        "max.message.bytes" = "1048576"
-        "compression.type"  = "zstd"
-        "cleanup.policy"    = "delete"
-    }
+  name               = "auth-customer.iam-credentials-v1-public"
+  replication_factor = 3
+  parititions        = 10
+  config = {
+    # retain 100MB on each partition
+    "retention.bytes" = "104857600"
+    # keep data for 7 days
+    "retention.ms" = "604800000"
+    # allow max 1 MB for a message
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
 }
 
 module "iam_credentials_public_events_mapper" {
-    source  = "../../../modules/tls-app"
-    cert_comon_name= "auth-customer/credentials-public-events-mapper"
-    produce_topics = [kafka_topic.iam_credentials_v1_public.name]
-    consume_topics = [(kafka_topic.iam_credentials_v1)]
-    consume_groups = ["iam.public-events-mapper-iam-credentials_v1"]
+  source          = "../../../modules/tls-app"
+  cert_comon_name = "auth-customer/credentials-public-events-mapper"
+  produce_topics  = [kafka_topic.iam_credentials_v1_public.name]
+  consume_topics  = [(kafka_topic.iam_credentials_v1)]
+  consume_groups  = ["iam.public-events-mapper-iam-credentials_v1"]
 }

--- a/dev-aws/kafka-shared/iam/iam.tf
+++ b/dev-aws/kafka-shared/iam/iam.tf
@@ -233,3 +233,28 @@ resource "kafka_topic" "iam_revoked_v1" {
     "cleanup.policy"    = "delete"
   }
 }
+
+
+resource "kafka_topic" "iam_password_change_forwarder_v1" {
+    name = "auth.iam-password-change-forwarder-v1"
+    replication_factor = 3
+    parititions = 1
+    config = {
+        # retain 100MB on each partition
+        "retention.bytes" = "104857600"
+        # keep data for 7 days
+        "retention.ms" = "604800000"
+        # allow max 1 MB for a message
+        "max.message.bytes" = "1048576"
+        "compression.type"  = "zstd"
+        "cleanup.policy"    = "delete"
+    }
+}
+
+module "iam_password_change_processor" {
+    source  = "../../../mmodules/tls-app"
+    cert_comon_name= "auth-customer/password-change-processor"
+    produce_topics = [kafka_topic.iam_password_change_forwarder_v1.name]
+    consume_topics = [(kafka_topic.iam_credentials_v1)]
+    consume_groups = ["iam.password-change-forwarder"]
+}


### PR DESCRIPTION
Draft for new topic that will allow CBC to access the password management events produced by auth-customer.iam-credentials-v1