### PR TITLE
fix tf resource name

### DIFF
--- a/dev-aws/kafka-shared-msk/customer-proposition/customer-proposition.tf
+++ b/dev-aws/kafka-shared-msk/customer-proposition/customer-proposition.tf
@@ -1,4 +1,4 @@
-resource "kafka_topic" "uswitch.data.v1" {
+resource "kafka_topic" "uswitch_data_v1" {
   name = "customer-proposition.uswitch.data.v1"
 
   replication_factor = 3


### PR DESCRIPTION

error message in tf applier ui: `unable to init module: err:exit status 1 Error: Invalid resource name on customer-proposition.tf line 1, in resource "kafka_topic" "uswitch.data.v1": 1: resource "kafka_topic" "uswitch.data.v1" { A name must start with a letter or underscore and may contain only letters, digits, underscores, and dashes.`
