### PR TITLE
pubsub-examples msk: decrease the retention policy

### DIFF
--- a/dev-aws/kafka-shared-msk/pubsub/pubsub-examples.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/pubsub-examples.tf
@@ -3,10 +3,10 @@ resource "kafka_topic" "pubsub_examples" {
   replication_factor = 3
   partitions         = 10
   config = {
-    # retain 100MB on each partition
-    "retention.bytes" = "104857600"
-    # keep data for 2 days
-    "retention.ms" = "172800000"
+    # retain 10MB on each partition
+    "retention.bytes" = "10485760"
+    # keep data for 6 hours
+    "retention.ms" = "21600000"
     # allow max 1 MB for a message
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"


### PR DESCRIPTION
It contains only temporary data, so we didn't need to keep it for that long