### PR TITLE
correct consumer topic for iam_credentials_public_events_mapper tls-app

### DIFF
--- a/dev-aws/kafka-shared/iam/iam.tf
+++ b/dev-aws/kafka-shared/iam/iam.tf
@@ -255,6 +255,6 @@ module "iam_credentials_public_events_mapper" {
   source           = "../../../modules/tls-app"
   cert_common_name = "auth-customer/credentials-public-events-mapper"
   produce_topics   = [kafka_topic.iam_credentials_v1_public.name]
-  consume_topics   = [(kafka_topic.iam_credentials_v1)]
+  consume_topics   = [(kafka_topic.iam_credentials_v1.name)]
   consume_groups   = ["iam.public-events-mapper-iam-credentials_v1"]
 }


### PR DESCRIPTION
accidentally used the topic instead of the topic name as input for consumer topic so this fixes that 