### PR TITLE
[BEX-482] add dummy topic

### DIFF
--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -236,6 +236,10 @@ resource "kafka_topic" "account-payment-details_v1" {
   }
 }
 
+# The dummy topic is used in some services that are deployed
+# multiple times to avoid reacting on the same events multiple
+# times. This topic should never receive an event. It is a way to 
+# make a topic optional when the service doesn't support that.
 resource "kafka_topic" "dummy" {
   name               = "dummy"
   replication_factor = 1

--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -235,3 +235,17 @@ resource "kafka_topic" "account-payment-details_v1" {
     "cleanup.policy"    = "delete"
   }
 }
+
+resource "kafka_topic" "dummy" {
+  name               = "dummy"
+  replication_factor = 1
+  partitions         = 1
+  config = {
+    "compression.type" = "zstd"
+    # retain 8GB on each partition
+    "retention.bytes" = "8053063680"
+    # allow max 1MB for a message
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}


### PR DESCRIPTION
We had 3 different dummy topics on our old cluster. They were used when services should not read events but the code didn't have the topic as optional. This topic will be used for all those cases. It should never have any events on it