### PR TITLE
[PLA2-95] allow test proximo access to shared kafka cluster

### DIFF
--- a/dev-aws/kafka-shared/dev-enablement/proximo-examples.tf
+++ b/dev-aws/kafka-shared/dev-enablement/proximo-examples.tf
@@ -1,0 +1,23 @@
+resource "kafka_topic" "proximo_example" {
+  name               = "dev-enablement.proximo-example"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    # retain 100MB on each partition
+    "retention.bytes" = "104857600"
+    # keep data for 2 days
+    "retention.ms" = "172800000"
+    # allow max 1 MB for a message
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+module "example_proximo" {
+  source           = "../../../modules/tls-app"
+  produce_topics   = [kafka_topic.proximo_example.name]
+  consume_topics   = [(kafka_topic.proximo_example.name)]
+  consume_groups   = ["dev-enablement.example-proximo"]
+  cert_common_name = "dev-enablement/example-proximo"
+}

--- a/dev-aws/kafka-shared/dev-enablement/proximo-examples.tf
+++ b/dev-aws/kafka-shared/dev-enablement/proximo-examples.tf
@@ -1,7 +1,7 @@
 resource "kafka_topic" "proximo_example" {
   name               = "dev-enablement.proximo-example"
   replication_factor = 3
-  partitions         = 10
+  partitions         = 3
   config = {
     # retain 100MB on each partition
     "retention.bytes" = "104857600"


### PR DESCRIPTION
Add test config configuration, in order to test the proximo instance