### PR TITLE
[BEX-793] add topics for the exstream and bex fulfillment

### DIFF
--- a/dev-aws/customer-billing/topics.tf
+++ b/dev-aws/customer-billing/topics.tf
@@ -417,3 +417,31 @@ resource "kafka_topic" "dummy-placeholder" {
     "cleanup.policy"    = "delete"
   }
 }
+
+# this topic is used during the transition from exstream to bex bill
+# generation and contains AccountReadyToBeFulfilledEvents 
+resource "kafka_topic" "transition-exstream-fulfilment" {
+  name               = "transition.exstream-fulfilment"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type"  = "zstd"
+    "retention.bytes"   = "8053063680"
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+# this topic is used during the transition from exstream to bex bill
+# generation and contains AccountReadyToBeFulfilledEvents 
+resource "kafka_topic" "transition-bex-fulfilment" {
+  name               = "transition.bex-fulfilment"
+  replication_factor = 3
+  partitions         = 20
+  config = {
+    "compression.type"  = "zstd"
+    "retention.bytes"   = "8053063680"
+    "max.message.bytes" = "1048588"
+    "cleanup.policy"    = "delete"
+  }
+}

--- a/dev-aws/customer-billing/topics.tf
+++ b/dev-aws/customer-billing/topics.tf
@@ -420,8 +420,8 @@ resource "kafka_topic" "dummy-placeholder" {
 
 # this topic is used during the transition from exstream to bex bill
 # generation and contains AccountReadyToBeFulfilledEvents 
-resource "kafka_topic" "transition-exstream-fulfilment" {
-  name               = "transition.exstream-fulfilment"
+resource "kafka_topic" "transition_exstream_fulfilment_request" {
+  name               = "transition.exstream.fulfilment_request"
   replication_factor = 3
   partitions         = 10
   config = {
@@ -434,8 +434,8 @@ resource "kafka_topic" "transition-exstream-fulfilment" {
 
 # this topic is used during the transition from exstream to bex bill
 # generation and contains AccountReadyToBeFulfilledEvents 
-resource "kafka_topic" "transition-bex-fulfilment" {
-  name               = "transition.bex-fulfilment"
+resource "kafka_topic" "transition_bex_fulfilment_request" {
+  name               = "transition.bex.fulfilment_request"
   replication_factor = 3
   partitions         = 20
   config = {

--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -257,8 +257,8 @@ resource "kafka_topic" "dummy" {
 
 # this topic is used during the transition from exstream to bex bill
 # generation and contains AccountReadyToBeFulfilledEvents 
-resource "kafka_topic" "transition-exstream-fulfilment" {
-  name               = "transition.exstream-fulfilment"
+resource "kafka_topic" "transition_exstream_fulfilment_request" {
+  name               = "transition.exstream.fulfilment_request"
   replication_factor = 3
   partitions         = 10
   config = {
@@ -272,8 +272,8 @@ resource "kafka_topic" "transition-exstream-fulfilment" {
 
 # this topic is used during the transition from exstream to bex bill
 # generation and contains AccountReadyToBeFulfilledEvents 
-resource "kafka_topic" "transition-bex-fulfilment" {
-  name               = "transition.bex-fulfilment"
+resource "kafka_topic" "transition_bex_fulfilment_request" {
+  name               = "transition.bex.fulfilment_request"
   replication_factor = 3
   partitions         = 20
   config = {

--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -253,3 +253,34 @@ resource "kafka_topic" "dummy" {
     "cleanup.policy"    = "delete"
   }
 }
+
+
+# this topic is used during the transition from exstream to bex bill
+# generation and contains AccountReadyToBeFulfilledEvents 
+resource "kafka_topic" "transition-exstream-fulfilment" {
+  name               = "transition.exstream-fulfilment"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    "retention.bytes"  = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+# this topic is used during the transition from exstream to bex bill
+# generation and contains AccountReadyToBeFulfilledEvents 
+resource "kafka_topic" "transition-bex-fulfilment" {
+  name               = "transition.bex-fulfilment"
+  replication_factor = 3
+  partitions         = 20
+  config = {
+    "compression.type" = "zstd"
+    "retention.bytes"  = "8053063680"
+    # allow max 100MB for a message
+    "max.message.bytes" = "104857600"
+    "cleanup.policy"    = "delete"
+  }
+}


### PR DESCRIPTION
This are temporary topics that will only live for the transition towards bex generated bills. That is the reason we are adding them here rather than on the shared kafka. 