### PR TITLE
DENA-522: Fixed tflint terraform_required_version & enabled the rule

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -8,11 +8,6 @@ rule "terraform_standard_module_structure" {
   enabled = false
 }
 
-# Suppressing this until we fix it
-rule "terraform_required_version" {
-  enabled = false
-}
-
 # Include module calls
 config {
   module = true

--- a/dev-aws/customer-billing/provider.tf
+++ b/dev-aws/customer-billing/provider.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   required_providers {
     kafka = {
       source  = "Mongey/kafka"

--- a/dev-aws/finance/provider.tf
+++ b/dev-aws/finance/provider.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   required_providers {
     kafka = {
       source  = "Mongey/kafka"

--- a/dev-aws/kafka-shared-msk/__env.tf
+++ b/dev-aws/kafka-shared-msk/__env.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   backend "s3" {}
 
   required_providers {

--- a/dev-aws/kafka-shared/__env.tf
+++ b/dev-aws/kafka-shared/__env.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   backend "s3" {}
 
   required_providers {

--- a/exp-1-merit/kafka-shared/provider.tf
+++ b/exp-1-merit/kafka-shared/provider.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   required_providers {
     kafka = {
       source  = "Mongey/kafka"

--- a/exp-1-merit/pubsub-msk/provider.tf
+++ b/exp-1-merit/pubsub-msk/provider.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   required_providers {
     kafka = {
       source  = "Mongey/kafka"

--- a/modules/tls-app/provider.tf
+++ b/modules/tls-app/provider.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   required_providers {
     kafka = {
       source  = "Mongey/kafka"

--- a/prod-aws/customer-billing/provider.tf
+++ b/prod-aws/customer-billing/provider.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   required_providers {
     kafka = {
       source  = "Mongey/kafka"

--- a/prod-aws/finance/provider.tf
+++ b/prod-aws/finance/provider.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   required_providers {
     kafka = {
       source  = "Mongey/kafka"

--- a/prod-aws/kafka-shared-msk/__env.tf
+++ b/prod-aws/kafka-shared-msk/__env.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   backend "s3" {}
 
   required_providers {

--- a/prod-aws/kafka-shared/__env.tf
+++ b/prod-aws/kafka-shared/__env.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.5.0"
 
   backend "s3" {}
 


### PR DESCRIPTION
The rule is described here: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_required_version.md 

Picked 1.5.0 as the minimum version as it's not very old, but not very recent either, it is from [12 June 2023](https://github.com/hashicorp/terraform/releases/tag/v1.5.0) and should work with repo