### PR TITLE
[BEX-801] add new consumer for invoice_fulfillment_deadletter

### DIFF
--- a/dev-aws/kafka-shared/customer-billing/customer-billing.tf
+++ b/dev-aws/kafka-shared/customer-billing/customer-billing.tf
@@ -46,3 +46,9 @@ module "billing_fulfilment_public_events_translator" {
   consume_groups   = ["bex.billing-fulfilment-public-events-translator"]
 }
 
+module "fulfilment_router" {
+  source           = "../../../modules/tls-app"
+  cert_common_name = "customer-billing/fulfilment-router"
+  consume_topics   = [(kafka_topic.invoice_fulfillment_deadletter.name)]
+  consume_groups   = ["bex.fulfilment-router"]
+}

--- a/prod-aws/kafka-shared/customer-billing/customer-billing.tf
+++ b/prod-aws/kafka-shared/customer-billing/customer-billing.tf
@@ -46,3 +46,9 @@ module "billing_fulfilment_public_events_translator" {
   consume_groups   = ["bex.billing-fulfilment-public-events-translator"]
 }
 
+module "fulfilment_router" {
+  source           = "../../../modules/tls-app"
+  cert_common_name = "customer-billing/fulfilment-router"
+  consume_topics   = [(kafka_topic.invoice_fulfillment_deadletter.name)]
+  consume_groups   = ["bex.fulfilment-router"]
+}


### PR DESCRIPTION
The new fulfilment-router will read the failed events from `invoice_fulfillment_deadletter` and reroute them to exstream.

This changes allow the router to consume from that topic