### PR TITLE
[BEX-824] allow mail sender to consume bex.internal.invoice_fulfilled

### DIFF
--- a/dev-aws/kafka-shared/customer-billing/customer-billing.tf
+++ b/dev-aws/kafka-shared/customer-billing/customer-billing.tf
@@ -52,3 +52,10 @@ module "fulfilment_router" {
   consume_topics   = [(kafka_topic.invoice_fulfillment_deadletter.name)]
   consume_groups   = ["bex.fulfilment-router"]
 }
+
+module "mail_sender" {
+  source           = "../../../modules/tls-app"
+  cert_common_name = "customer-billing/mail-sender"
+  consume_topics   = [(kafka_topic.invoice_fulfillment.name)]
+  consume_groups   = ["bex.mail-sender"]
+}


### PR DESCRIPTION
Allow the mail sender to consume from the bex.internal.bill_fulfilled topic