### PR TITLE
update consumer group for castle processor

### DIFF
--- a/dev-aws/kafka-shared-msk/iam/iam.tf
+++ b/dev-aws/kafka-shared-msk/iam/iam.tf
@@ -290,5 +290,5 @@ module "castle_processor" {
   source           = "../../../modules/tls-app"
   cert_common_name = "auth-customer/castle-processor"
   consume_topics   = [(kafka_topic.iam_credentials_v1.name)]
-  consume_groups   = ["iam.castle_processor"]
+  consume_groups   = ["iam.castle-processor"]
 }


### PR DESCRIPTION
fixes naming convention for consumer group created for iams castle processor.