### PR TITLE
[BEX-829] create production consumer&producer for mail sender

### DIFF
--- a/prod-aws/kafka-shared-msk/customer-billing/customer-billing.tf
+++ b/prod-aws/kafka-shared-msk/customer-billing/customer-billing.tf
@@ -11,3 +11,9 @@ resource "kafka_topic" "mail_sender_deadletter" {
     "cleanup.policy"    = "delete"
   }
 }
+
+module "mail_sender" {
+  source           = "../../../modules/tls-app"
+  cert_common_name = "customer-billing/mail-sender"
+  produce_topics   = [kafka_topic.mail_sender_deadletter.name]
+}

--- a/prod-aws/kafka-shared/customer-billing/customer-billing.tf
+++ b/prod-aws/kafka-shared/customer-billing/customer-billing.tf
@@ -52,3 +52,16 @@ module "fulfilment_router" {
   consume_topics   = [(kafka_topic.invoice_fulfillment_deadletter.name)]
   consume_groups   = ["bex.fulfilment-router"]
 }
+
+module "mail_sender" {
+  source           = "../../../modules/tls-app"
+  cert_common_name = "customer-billing/mail-sender"
+  consume_topics   = [(kafka_topic.invoice_fulfillment.name)]
+  consume_groups   = ["bex.mail-sender"]
+}
+
+module "dashboard" {
+  source           = "../../../modules/tls-app"
+  cert_common_name = "customer-billing/bex-dashboard"
+  produce_topics   = [kafka_topic.invoice_fulfillment.name]
+}


### PR DESCRIPTION
Copies the configuration from dev. Creates a consumer for the existing bex.internal.bill_fulfilled topic on the shared kafka and a new producer for bex.internal.mail_sender_deadletter on the shared msk kafka cluster.

Also adds the dashboard producer for manual testing.