### PR TITLE
chore(finance):Migrate kafka topics #898 

### DIFF
--- a/dev-aws/finance/account-enrichment.tf
+++ b/dev-aws/finance/account-enrichment.tf
@@ -1,0 +1,23 @@
+# tflint-ignore: terraform_naming_convention
+resource "kafka_topic" "account-enrichment-events" {
+  name               = "account-enrichment.events"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "retention.bytes" = "-1"
+    "retention.ms"    = "2592000000"
+    "cleanup.policy"  = "delete"
+  }
+}
+
+# tflint-ignore: terraform_naming_convention
+resource "kafka_topic" "account-enrichment-eqdb-loader-customer-events" {
+  name               = "account-enrichment.eqdb-loader.customer.events"
+  replication_factor = 3
+  partitions         = 1
+  config = {
+    "retention.bytes" = "-1"
+    "retention.ms"    = "2592000000"
+    "cleanup.policy"  = "delete"
+  }
+}

--- a/dev-aws/finance/account-legacy.tf
+++ b/dev-aws/finance/account-legacy.tf
@@ -1,0 +1,11 @@
+# tflint-ignore: terraform_naming_convention
+resource "kafka_topic" "legacy-account-events-fwd" {
+  name               = "legacy.account.events.fwd"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "retention.bytes" = "-1"
+    "retention.ms"    = "2592000000"
+    "cleanup.policy"  = "delete"
+  }
+}


### PR DESCRIPTION
This PR is a a breakdown of #750
https://linear.app/utilitywarehouse/issue/FIN-898/migrate-account-events-related-topics

Create two new tf files for the new kafka configs (x3)

legacy.account.events.fwd
account-enrichment.events
account-enrichment.eqdb-loader.customer.events