### PR TITLE
[BEX-864] remove duplicated module

### DIFF
--- a/dev-aws/kafka-shared-msk/customer-billing/consumers.tf
+++ b/dev-aws/kafka-shared-msk/customer-billing/consumers.tf
@@ -18,10 +18,3 @@ module "fulfilment_router" {
   consume_topics   = [(kafka_topic.invoice_fulfillment_deadletter.name)]
   consume_groups   = ["bex.fulfilment-router"]
 }
-
-module "mail_sender" {
-  source           = "../../../modules/tls-app"
-  cert_common_name = "customer-billing/mail-sender"
-  consume_topics   = [(kafka_topic.invoice_fulfillment.name)]
-  consume_groups   = ["bex.mail-sender"]
-}

--- a/dev-aws/kafka-shared-msk/customer-billing/producers.tf
+++ b/dev-aws/kafka-shared-msk/customer-billing/producers.tf
@@ -2,6 +2,8 @@ module "mail_sender" {
   source           = "../../../modules/tls-app"
   cert_common_name = "customer-billing/mail-sender"
   produce_topics   = [kafka_topic.mail_sender_deadletter.name]
+  consume_topics   = [(kafka_topic.invoice_fulfillment.name)]
+  consume_groups   = ["bex.mail-sender"]
 }
 
 module "invoice_generator" {

--- a/prod-aws/kafka-shared-msk/customer-billing/consumers.tf
+++ b/prod-aws/kafka-shared-msk/customer-billing/consumers.tf
@@ -18,10 +18,3 @@ module "fulfilment_router" {
   consume_topics   = [(kafka_topic.invoice_fulfillment_deadletter.name)]
   consume_groups   = ["bex.fulfilment-router"]
 }
-
-module "mail_sender" {
-  source           = "../../../modules/tls-app"
-  cert_common_name = "customer-billing/mail-sender"
-  consume_topics   = [(kafka_topic.invoice_fulfillment.name)]
-  consume_groups   = ["bex.mail-sender"]
-}

--- a/prod-aws/kafka-shared-msk/customer-billing/producers.tf
+++ b/prod-aws/kafka-shared-msk/customer-billing/producers.tf
@@ -2,6 +2,8 @@ module "mail_sender" {
   source           = "../../../modules/tls-app"
   cert_common_name = "customer-billing/mail-sender"
   produce_topics   = [kafka_topic.mail_sender_deadletter.name]
+  consume_topics   = [(kafka_topic.invoice_fulfillment.name)]
+  consume_groups   = ["bex.mail-sender"]
 }
 
 module "invoice_generator" {


### PR DESCRIPTION
The terraform applier failed with: 
```
Error: Duplicate module call

  on producers.tf line 1:
   1: module "mail_sender" {

A module call named "mail_sender" was already defined at
consumers.tf:22,1-21. Module calls must have unique names within a module.
```

Combine the consumer&producer in one module. I will rethink the filenames later