### PR TITLE
chore(finance): migrate kafka topics dd rejections #900 [DEV]

### DIFF
--- a/dev-aws/finance/direct-debits.tf
+++ b/dev-aws/finance/direct-debits.tf
@@ -74,3 +74,14 @@ resource "kafka_topic" "dd_rejections_file_available_events" {
     "cleanup.policy"  = "delete"
   }
 }
+
+resource "kafka_topic" "dd_rejections_fabrication_failures" {
+  name               = "dd-rejections-fabrication-failures"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "retention.bytes" = "-1"
+    "retention.ms"    = "604800000"
+    "cleanup.policy"  = "delete"
+  }
+}

--- a/dev-aws/finance/direct-debits.tf
+++ b/dev-aws/finance/direct-debits.tf
@@ -63,3 +63,14 @@ resource "kafka_topic" "dd_file_upload_results_events" {
     "cleanup.policy"  = "delete"
   }
 }
+
+resource "kafka_topic" "dd_rejections_file_available_events" {
+  name               = "dd-rejections-file-available-events"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "retention.bytes" = "-1"
+    "retention.ms"    = "604800000"
+    "cleanup.policy"  = "delete"
+  }
+}


### PR DESCRIPTION
This PR is a breakdown of #750

https://linear.app/utilitywarehouse/issue/FIN-899/migrate-topics-related-to-debt-payments-page

Added to the direct-debits.tf two new kafka topics:

- dd_rejections_file_available_events
- dd_rejections_fabrication_failures
