### PR TITLE
Bp di kafka source config

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -152,3 +152,15 @@ module "budget_plan_assessment" {
   consume_groups   = ["energy-budget-plan.assessment-v1"]
   cert_common_name = "energy-budget-plan/assessment"
 }
+
+module "budget_plan_di_kafka_source" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = [kafka_topic.budget_plan.name]
+  consume_groups   = [
+    "energy-budget-plan.di-kafka-source-calculation-requests-v1",
+    "energy-budget-plan.di-kafka-source-recommendations-v1",
+    "energy-budget-plan.di-kafka-source-budget-plan-changed-v1",
+    "energy-budget-plan.di-kafka-source-budget-plan-not-changed-v1",
+  ]
+  cert_common_name = "energy-budget-plan/di-kafka-source-assessments"
+}

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -154,9 +154,9 @@ module "budget_plan_assessment" {
 }
 
 module "budget_plan_di_kafka_source" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.budget_plan.name]
-  consume_groups   = [
+  source         = "../../../modules/tls-app"
+  consume_topics = [kafka_topic.budget_plan.name]
+  consume_groups = [
     "energy-budget-plan.di-kafka-source-calculation-requests-v1",
     "energy-budget-plan.di-kafka-source-recommendations-v1",
     "energy-budget-plan.di-kafka-source-budget-plan-changed-v1",

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/energy-budget-plan.tf
@@ -162,5 +162,5 @@ module "budget_plan_di_kafka_source" {
     "energy-budget-plan.di-kafka-source-budget-plan-changed-v1",
     "energy-budget-plan.di-kafka-source-budget-plan-not-changed-v1",
   ]
-  cert_common_name = "energy-budget-plan/di-kafka-source-assessments"
+  cert_common_name = "energy-budget-plan/di-kafka-source"
 }


### PR DESCRIPTION
define access for di-kafka-source applications; 

Will migrate from having certificate/di-kafka-source per app to have a single certificate for all this related deployments to share.

Once the deployments are migrated in manifests, will follow up a PR to clean the ones defined per deployment 