### PR TITLE
BTGWS-1340: Use legacy `corp-*` kube namespace for cert prefix

### DIFF
--- a/prod-aws/kafka-shared-msk/workplace-infrastructure/netapp-audit.tf
+++ b/prod-aws/kafka-shared-msk/workplace-infrastructure/netapp-audit.tf
@@ -37,5 +37,5 @@ module "workplace_infrastructure_netapp_audit_publish_to_kafka" {
     kafka_topic.workplace_infrastructure_netapp_audit_v1_cifs_svm_a.name,
     kafka_topic.workplace_infrastructure_netapp_audit_v1_cifs_svm_b.name
   ]
-  cert_common_name = "workplace-infrastructure/netapp-audit-publish-to-kafka"
+  cert_common_name = "corp-netapp-audit/netapp-audit-publish-to-kafka"
 }


### PR DESCRIPTION
Some insistance we use legacy "corp*" namespace for kube
Rule on cert name enforced by kyverno