### PR TITLE
[BEX-938] - Double retention time of transition.bex.fulfilment_request.

### DIFF
--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -300,6 +300,6 @@ resource "kafka_topic" "transition_bex_fulfilment_request" {
     "max.message.bytes" = "104857600"
     "cleanup.policy"    = "delete"
     # keep data for 14 days
-    "retention.ms" = "1209600000"
+    "retention.ms" = "2419200000"
   }
 }

--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -299,7 +299,7 @@ resource "kafka_topic" "transition_bex_fulfilment_request" {
     # allow max 100MB for a message
     "max.message.bytes" = "104857600"
     "cleanup.policy"    = "delete"
-    # keep data for 14 days
+    # keep data for 28 days to facilitate performance testing
     "retention.ms" = "2419200000"
   }
 }


### PR DESCRIPTION
Double the topic's retention to facilitate our performance testing.