### PR TITLE
DENA-823: Add new user tf-kafka-config-admin that has admin permissions

### DIFF
--- a/dev-aws/kafka-shared-msk/pubsub/tf-kafka-config-admin.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/tf-kafka-config-admin.tf
@@ -1,0 +1,28 @@
+# Grant pubsub/tf-kafka-config-admin permission to all the resources
+resource "kafka_acl" "tf_kafka_config_admin_topic" {
+  resource_name       = "*"
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=pubsub/tf-kafka-config-admin"
+  acl_host            = "*"
+  acl_operation       = "All"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "tf_kafka_config_admin_group" {
+  resource_name       = "*"
+  resource_type       = "Group"
+  acl_principal       = "User:CN=pubsub/tf-kafka-config-admin"
+  acl_host            = "*"
+  acl_operation       = "All"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "tf_kafka_config_admin_cluster" {
+  resource_name                = "kafka-cluster"
+  resource_type                = "Cluster"
+  acl_principal                = "User:CN=pubsub/tf-kafka-config-admin"
+  acl_host                     = "*"
+  acl_operation                = "All"
+  acl_permission_type          = "Allow"
+  resource_pattern_type_filter = "Literal"
+}

--- a/prod-aws/kafka-shared-msk/pubsub/tf-kafka-config-admin.tf
+++ b/prod-aws/kafka-shared-msk/pubsub/tf-kafka-config-admin.tf
@@ -1,0 +1,28 @@
+# Grant pubsub/tf-kafka-config-admin permission to all the resources
+resource "kafka_acl" "tf_kafka_config_admin_topic" {
+  resource_name       = "*"
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=pubsub/tf-kafka-config-admin"
+  acl_host            = "*"
+  acl_operation       = "All"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "tf_kafka_config_admin_group" {
+  resource_name       = "*"
+  resource_type       = "Group"
+  acl_principal       = "User:CN=pubsub/tf-kafka-config-admin"
+  acl_host            = "*"
+  acl_operation       = "All"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "tf_kafka_config_admin_cluster" {
+  resource_name                = "kafka-cluster"
+  resource_type                = "Cluster"
+  acl_principal                = "User:CN=pubsub/tf-kafka-config-admin"
+  acl_host                     = "*"
+  acl_operation                = "All"
+  acl_permission_type          = "Allow"
+  resource_pattern_type_filter = "Literal"
+}


### PR DESCRIPTION
This user will be used by the dedicated pod setup to do terraform operations through kafka-cluster-config. See the ticket for the full solution: https://linear.app/utilitywarehouse/issue/DENA-823/msk-do-not-roll-brokers-for-topic-deletes