### PR TITLE
DENA-823: msk: add topic to validate the deletion of topics in prod

### DIFF
--- a/prod-aws/kafka-shared-msk/pubsub/delete-topic-test.tf
+++ b/prod-aws/kafka-shared-msk/pubsub/delete-topic-test.tf
@@ -1,0 +1,16 @@
+# This is a temporary topic to validate the handling of deleting topics in the MSK runbook
+resource "kafka_topic" "test_delete_topic" {
+  name               = "test.topic-to-delete"
+  replication_factor = 3
+  partitions         = 1
+  config = {
+    # retain 100MB on each partition
+    "retention.bytes" = "104857600"
+    # keep data for 2 days
+    "retention.ms" = "172800000"
+    # allow max 1 MB for a message
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}


### PR DESCRIPTION
Using a dummy topic that we'll try to delete using the new procedure in the runbook: https://wiki.uw.systems/posts/shared-kafka-on-aws-msk-runbook-10pijp5z#hfmwq-terraform-applier-errors