### PR TITLE
DENA-750: Add new user msk-admin-client that has admin permissions.

### DIFF
--- a/dev-aws/kafka-shared-msk/pubsub/msk-admin-client.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/msk-admin-client.tf
@@ -1,0 +1,28 @@
+# pubsub/msk-admin-client is used for various admin manual tasks by the pubsub team. Grant all permissions to all the resources.
+resource "kafka_acl" "msk_admin_client_topic" {
+  resource_name       = "*"
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=pubsub/msk-admin-client"
+  acl_host            = "*"
+  acl_operation       = "All"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "msk_admin_client_group" {
+  resource_name       = "*"
+  resource_type       = "Group"
+  acl_principal       = "User:CN=pubsub/msk-admin-client"
+  acl_host            = "*"
+  acl_operation       = "All"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "msk_admin_client_cluster" {
+  resource_name                = "kafka-cluster"
+  resource_type                = "Cluster"
+  acl_principal                = "User:CN=pubsub/msk-admin-client"
+  acl_host                     = "*"
+  acl_operation                = "All"
+  acl_permission_type          = "Allow"
+  resource_pattern_type_filter = "Literal"
+}

--- a/prod-aws/kafka-shared-msk/pubsub/msk-admin-client.tf
+++ b/prod-aws/kafka-shared-msk/pubsub/msk-admin-client.tf
@@ -1,0 +1,28 @@
+# pubsub/msk-admin-client is used for various admin manual tasks by the pubsub team. Grant all permissions to all the resources.
+resource "kafka_acl" "msk_admin_client_topic" {
+  resource_name       = "*"
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=pubsub/msk-admin-client"
+  acl_host            = "*"
+  acl_operation       = "All"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "msk_admin_client_group" {
+  resource_name       = "*"
+  resource_type       = "Group"
+  acl_principal       = "User:CN=pubsub/msk-admin-client"
+  acl_host            = "*"
+  acl_operation       = "All"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "msk_admin_client_cluster" {
+  resource_name                = "kafka-cluster"
+  resource_type                = "Cluster"
+  acl_principal                = "User:CN=pubsub/msk-admin-client"
+  acl_host                     = "*"
+  acl_operation                = "All"
+  acl_permission_type          = "Allow"
+  resource_pattern_type_filter = "Literal"
+}


### PR DESCRIPTION
This will replace the [tf-kafka-config-admin](https://github.com/utilitywarehouse/kafka-cluster-config/commit/75d10d11dc2ec1e320157e301314e27f308f5e7f) user as it will be used for applying the kafka-config manually too.