### PR TITLE
otel prod: reduce the retention period to 12h

### DIFF
--- a/prod-aws/otel/otel.tf
+++ b/prod-aws/otel/otel.tf
@@ -5,8 +5,8 @@ resource "kafka_topic" "otlp_spans" {
   config = {
     # retain 5GB on each partition
     "retention.bytes" = "5368709120"
-    # keep data for 1 day
-    "retention.ms" = "86400000"
+    # keep data for 12 hours
+    "retention.ms" = "43200000"
     # allow max 128 MB for a message
     "max.message.bytes" = "134217728"
     # roll log at 3h max


### PR DESCRIPTION
The current 1d period doesn't give us to much space for spikes lately:
https://grafana.prod.aws.uw.systems/d/919b92a8e8041bd567af9edab12c840c/kubernetes-persistent-volumes?var-datasource=default&var-cluster=prod-aws&var-namespace=otel&var-volume=data-kafka-bitnami-2&from=now-2d&to=now

This change means that Tempo has 12h to ingest the data produced, otherwise it will be dropped, which seems fair.