### PR TITLE
FIN-1201: Rename topic to match original

### DIFF
--- a/dev-aws/kafka-shared-msk/billing/data-staged-events.tf
+++ b/dev-aws/kafka-shared-msk/billing/data-staged-events.tf
@@ -1,5 +1,5 @@
 resource "kafka_topic" "data_staged_events_finance" {
-  name               = "billing.data-staged-events-finance"
+  name               = "billing.DataStagedEventsFinance"
   replication_factor = 3
   partitions         = 10
   config = {


### PR DESCRIPTION
As per [discussion](https://utilitywarehouse.slack.com/archives/C0536L8V7EU/p1724831001584389?thread_ts=1724830851.691959&cid=C0536L8V7EU) the new topic should be named exactly like the old topic + team prefix.