### PR TITLE
chore(FIN-1154): Update TLS certificates for 'finance-bigquery-connector' as producer [DEV]

### DIFF
--- a/dev-aws/kafka-shared-msk/billing/data-staged-events.tf
+++ b/dev-aws/kafka-shared-msk/billing/data-staged-events.tf
@@ -42,6 +42,9 @@ module "finance_bigquery_connector" {
   consume_topics = [
     kafka_topic.data_staged_events_finance.name,
   ]
+  produce_topics = [
+    kafka_topic.historical_data_staged_events_finance.name,
+  ]
   consume_groups   = ["billing.finance-bigquery-connector"]
   cert_common_name = "billing/finance-bigquery-connector"
 }


### PR DESCRIPTION
`billing/finance-bigquery-connector` service publishes messages to `historical-data-staged-events-finance` topic.

Follow up of #476 