### PR TITLE
DENA-901: billing: throttle finance_tx_log_staging_connector

### DIFF
--- a/prod-aws/kafka-shared-msk/billing/data-staged-events.tf
+++ b/prod-aws/kafka-shared-msk/billing/data-staged-events.tf
@@ -54,6 +54,8 @@ module "finance_tx_log_staging_connector" {
   produce_topics = [
     kafka_topic.data_staged_events_finance.name,
   ]
+  #  limit to 150 KB per broker, as the consumer doesn't keep up with the producer and the producer is loading the brokers CPU when not throttled.
+  producer_byte_rate = "153600"
   cert_common_name = "billing/finance-tx-log-staging-connector"
 }
 

--- a/prod-aws/kafka-shared-msk/billing/data-staged-events.tf
+++ b/prod-aws/kafka-shared-msk/billing/data-staged-events.tf
@@ -56,7 +56,7 @@ module "finance_tx_log_staging_connector" {
   ]
   #  limit to 150 KB per broker, as the consumer doesn't keep up with the producer and the producer is loading the brokers CPU when not throttled.
   producer_byte_rate = "153600"
-  cert_common_name = "billing/finance-tx-log-staging-connector"
+  cert_common_name   = "billing/finance-tx-log-staging-connector"
 }
 
 module "historical_bigquery_connector" {


### PR DESCRIPTION
After we scaled out the cluster, the producer doubled the throughput and the lag increased significantly to 2.5 Mil records on the big-query-connector.

See this dashboard: https://grafana.prod.aws.uw.systems/d/rrE2HgHVz/msk-kafka-metrics?orgId=1&from=now-6h&to=now&refresh=30s&var-job=msk-shared&var-broker=All&var-topic=billing.DataStagedEventsFinance&var-consumergroup=All

I chose the value of 150KB from the above graph