### PR TITLE
chore(FIN-1204) create kafka topic and module [DEV]

### DIFF
--- a/dev-aws/kafka-shared-msk/billing/transactions-auditor-diff-events.tf
+++ b/dev-aws/kafka-shared-msk/billing/transactions-auditor-diff-events.tf
@@ -1,0 +1,28 @@
+resource "kafka_topic" "transactions_auditor_diff_events" {
+  name               = "billing.transactions-auditor-diff.events"
+  replication_factor = 3
+  partitions         = 10
+  config = {
+    "compression.type" = "zstd"
+    # 805 GB
+    "retention.bytes" = "805306368000"
+    # 105 MB
+    "max.message.bytes" = "104857600"
+    # Use tiered storage
+    "remote.storage.enable" = "true"
+    # keep data in hot storage for 2 days
+    "local.retention.ms" = "172800000"
+    "retention.ms"       = "-1"
+    "cleanup.policy"     = "delete"
+  }
+}
+
+module "transactions-auditor-api" {
+  source = "../../../modules/tls-app"
+  // consume_topics = [ index? ]
+  produce_topics = [
+    kafka_topic.transactions-auditor-diff.events.name,
+  ]
+  // consume_groups   = ["billing.finance-bigquery-connector"]
+  cert_common_name = "billing/finance-bigquery-connector"
+}

--- a/dev-aws/kafka-shared-msk/billing/transactions-auditor-diff-events.tf
+++ b/dev-aws/kafka-shared-msk/billing/transactions-auditor-diff-events.tf
@@ -17,12 +17,13 @@ resource "kafka_topic" "transactions_auditor_diff_events" {
   }
 }
 
+
 module "transactions-auditor-api" {
   source = "../../../modules/tls-app"
-  // consume_topics = [ index? ]
+  // consume_topics = [transactions-auditor-events-indexer.name,]
   produce_topics = [
     kafka_topic.transactions-auditor-diff.events.name,
   ]
-  // consume_groups   = ["?"]
+  // consume_groups   = ["billing.transactions-auditor-events-indexer"]
   cert_common_name = "billing/transactions-auditor-api"
 }

--- a/dev-aws/kafka-shared-msk/billing/transactions-auditor-diff-events.tf
+++ b/dev-aws/kafka-shared-msk/billing/transactions-auditor-diff-events.tf
@@ -23,6 +23,6 @@ module "transactions-auditor-api" {
   produce_topics = [
     kafka_topic.transactions-auditor-diff.events.name,
   ]
-  // consume_groups   = ["billing.finance-bigquery-connector"]
-  cert_common_name = "billing/finance-bigquery-connector"
+  // consume_groups   = ["?"]
+  cert_common_name = "billing/transactions-auditor-api"
 }


### PR DESCRIPTION
This PR is the second installment of the kafka MSK project

First Part in ticket format: 
- https://linear.app/utilitywarehouse/issue/FIN-1247/update-transactions-auditor-to-use-new-pubsub-lib

Currently in discussion whether or not to migrate the consumer transactions-auditor-events-indexer before mirroring these topics. 