### PR TITLE
DENA-969: Split tflint configs between MSK and team clusters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,21 @@ repos:
   hooks:
     - id: terraform_fmt
     - id: terraform_tflint
+      name: Validate with tflint the uw hosted team configs
       args:
-        - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+        - --args=--config=__GIT_WORKING_DIR__/.tflint-uw-team-hosted.hcl
         # use compact, so that errors will be reported by the GH action see https://github.com/terraform-linters/setup-tflint?tab=readme-ov-file#checks
         - --args=--format=compact
-        - --hook-config=--delegate-chdir
+#        - --hook-config=--delegate-chdir
+      exclude: "^.*/kafka-shared-msk/.*$"
+    - id: terraform_tflint
+      name: Validate with tflint the MSK team configs
+      args:
+        - --args=--config=__GIT_WORKING_DIR__/.tflint-msk.hcl
+        # use compact, so that errors will be reported by the GH action see https://github.com/terraform-linters/setup-tflint?tab=readme-ov-file#checks
+        - --args=--format=compact
+#        - --hook-config=--delegate-chdir
+      files: "^.*/kafka-shared-msk/.*$"
     - id: terraform_validate
       args:
         # for local cached .terraform folders. Explanations in https://github.com/antonbabenko/pre-commit-terraform?tab=readme-ov-file#terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         # use compact, so that errors will be reported by the GH action see https://github.com/terraform-linters/setup-tflint?tab=readme-ov-file#checks
         - --args=--format=compact
         # We won't be able to use --hook-config=--delegate-chdir, as we need to determine the current folder in our plugin tflint-ruleset-kafka-config.
-      files: "^.*/kafka-shared-msk/.*$"
+      files: "^.*/kafka-shared-msk/.+/.*$"
     - id: terraform_validate
       args:
         # for local cached .terraform folders. Explanations in https://github.com/antonbabenko/pre-commit-terraform?tab=readme-ov-file#terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
         - --args=--config=__GIT_WORKING_DIR__/.tflint-uw-team-hosted.hcl
         # use compact, so that errors will be reported by the GH action see https://github.com/terraform-linters/setup-tflint?tab=readme-ov-file#checks
         - --args=--format=compact
+        # Using this allows issues to appear directly in the PR code. See https://github.com/antonbabenko/pre-commit-terraform?tab=readme-ov-file#terraform_tflint
         - --hook-config=--delegate-chdir
       exclude: "^.*/kafka-shared-msk/.*$"
     - id: terraform_tflint
@@ -17,7 +18,7 @@ repos:
         - --args=--config=__GIT_WORKING_DIR__/.tflint-msk.hcl
         # use compact, so that errors will be reported by the GH action see https://github.com/terraform-linters/setup-tflint?tab=readme-ov-file#checks
         - --args=--format=compact
-        - --hook-config=--delegate-chdir
+        # We won't be able to use --hook-config=--delegate-chdir, as we need to determine the current folder in our plugin tflint-ruleset-kafka-config.
       files: "^.*/kafka-shared-msk/.*$"
     - id: terraform_validate
       args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         - --args=--config=__GIT_WORKING_DIR__/.tflint-uw-team-hosted.hcl
         # use compact, so that errors will be reported by the GH action see https://github.com/terraform-linters/setup-tflint?tab=readme-ov-file#checks
         - --args=--format=compact
-#        - --hook-config=--delegate-chdir
+        - --hook-config=--delegate-chdir
       exclude: "^.*/kafka-shared-msk/.*$"
     - id: terraform_tflint
       name: Validate with tflint the MSK team configs
@@ -17,7 +17,7 @@ repos:
         - --args=--config=__GIT_WORKING_DIR__/.tflint-msk.hcl
         # use compact, so that errors will be reported by the GH action see https://github.com/terraform-linters/setup-tflint?tab=readme-ov-file#checks
         - --args=--format=compact
-#        - --hook-config=--delegate-chdir
+        - --hook-config=--delegate-chdir
       files: "^.*/kafka-shared-msk/.*$"
     - id: terraform_validate
       args:

--- a/.tflint-msk.hcl
+++ b/.tflint-msk.hcl
@@ -1,3 +1,5 @@
+# tflint configuration file that applies to all MSK team modules
+
 plugin "terraform" {
   enabled = true
   preset  = "all"
@@ -10,5 +12,5 @@ rule "terraform_standard_module_structure" {
 
 # Include module calls
 config {
-  module = true
+  call_module_type = "all"
 }

--- a/.tflint-uw-team-hosted.hcl
+++ b/.tflint-uw-team-hosted.hcl
@@ -1,0 +1,16 @@
+# tflint configuration file that applies to all UW hosted team cluster modules
+
+plugin "terraform" {
+  enabled = true
+  preset  = "all"
+}
+
+# I think it's too late for this and wouldn't make sense for our modules
+rule "terraform_standard_module_structure" {
+  enabled = false
+}
+
+# Include module calls
+config {
+  call_module_type = "all"
+}

--- a/dev-aws/kafka-shared-msk/pubsub/mirror-maker.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/mirror-maker.tf
@@ -16,7 +16,7 @@ resource "kafka_acl" "mirror_maker_group_access" {
   acl_permission_type = "Allow"
 }
 
-resource "kafka_acl" "mirror_maker_cluster_access" {
+resource "kafka_acl" "mirror-maker_cluster_access" {
   resource_name                = "kafka-cluster"
   resource_type                = "Cluster"
   acl_principal                = "User:CN=pubsub/mirror-maker"

--- a/dev-aws/kafka-shared-msk/pubsub/mirror-maker.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/mirror-maker.tf
@@ -16,7 +16,7 @@ resource "kafka_acl" "mirror_maker_group_access" {
   acl_permission_type = "Allow"
 }
 
-resource "kafka_acl" "mirror-maker_cluster_access" {
+resource "kafka_acl" "mirror_maker_cluster_access" {
   resource_name                = "kafka-cluster"
   resource_type                = "Cluster"
   acl_principal                = "User:CN=pubsub/mirror-maker"


### PR DESCRIPTION
We need to split this, as we want to implement rules that apply only for MSK modules