### PR TITLE
feat(FIN-1265): Add topic for credit insight validation errors [PROD]

### DIFF
--- a/prod-aws/finance/credit-insight.tf
+++ b/prod-aws/finance/credit-insight.tf
@@ -1,35 +1,11 @@
-# tflint-ignore: terraform_naming_convention
-resource "kafka_topic" "credit-insight-account-data-changed-events" {
-  name               = "credit-insight-account-data-changed.events"
-  replication_factor = 3
+resource "kafka_topic" "credit_insights_validation_errors" {
+  name               = "credit-insights-validation.errors"
   partitions         = 10
-  config = {
-    "retention.bytes" = "-1"
-    "retention.ms"    = "2592000000" #30 days
-    "cleanup.policy"  = "delete"
-  }
-}
+  replication_factor = 3
 
-# tflint-ignore: terraform_naming_convention
-resource "kafka_topic" "credit-insight-account-balance-changed-events" {
-  name               = "credit-insight-account-balance-changed.events"
-  replication_factor = 3
-  partitions         = 10
   config = {
     "retention.bytes" = "-1"
-    "retention.ms"    = "2592000000" #30 days
-    "cleanup.policy"  = "delete"
-  }
-}
-
-# tflint-ignore: terraform_naming_convention
-resource "kafka_topic" "credit-insight-account-changed-events" {
-  name               = "credit-insight-account-changed.events"
-  replication_factor = 3
-  partitions         = 10
-  config = {
-    "retention.bytes" = "-1"
-    "retention.ms"    = "-1" #forever
+    "retention.ms"    = "604800000" # 7 days since these events will be indexed
     "cleanup.policy"  = "delete"
   }
 }


### PR DESCRIPTION
It also remove unused topics for this initiative.

These topics aren't being used since a refactor was done to insights services: https://github.com/utilitywarehouse/finance-mono/pull/675

Related PR:
- https://github.com/utilitywarehouse/kafka-cluster-config/pull/498 