### PR TITLE
DENA-968: Add backend definition to modules

### DIFF
--- a/dev-aws/kafka-shared-msk/__env.tf
+++ b/dev-aws/kafka-shared-msk/__env.tf
@@ -1,8 +1,6 @@
 terraform {
   required_version = ">= 1.5.0"
 
-  backend "s3" {}
-
   required_providers {
     kafka = {
       source  = "Mongey/kafka"

--- a/dev-aws/kafka-shared-msk/account-identity/__backend.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-account-identity"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/billing/__backend.tf
+++ b/dev-aws/kafka-shared-msk/billing/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-billing"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/cbc/__backend.tf
+++ b/dev-aws/kafka-shared-msk/cbc/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-cbc"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/contact-channels/__backend.tf
+++ b/dev-aws/kafka-shared-msk/contact-channels/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-contact-channels"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/customer-billing/__backend.tf
+++ b/dev-aws/kafka-shared-msk/customer-billing/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-customer-billing"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/customer-proposition/__backend.tf
+++ b/dev-aws/kafka-shared-msk/customer-proposition/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-customer-proposition"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/customer-support/__backend.tf
+++ b/dev-aws/kafka-shared-msk/customer-support/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-customer-support"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/data-infra/__backend.tf
+++ b/dev-aws/kafka-shared-msk/data-infra/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-data-infra"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/energy-budget-plan/__backend.tf
+++ b/dev-aws/kafka-shared-msk/energy-budget-plan/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-energy-budget-plan"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/iam-audit/__backend.tf
+++ b/dev-aws/kafka-shared-msk/iam-audit/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-iam-audit"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/iam/__backend.tf
+++ b/dev-aws/kafka-shared-msk/iam/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-iam"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/payment-platform/__backend.tf
+++ b/dev-aws/kafka-shared-msk/payment-platform/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-payment-platform"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/pubsub/__backend.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-dev-pubsub-tf-applier-state"
+    key     = "dev-aws/kafka-shared-msk-pubsub"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/dev-aws/kafka-shared-msk/pubsub/mirror-maker.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/mirror-maker.tf
@@ -16,7 +16,7 @@ resource "kafka_acl" "mirror_maker_group_access" {
   acl_permission_type = "Allow"
 }
 
-resource "kafka_acl" "mirror_maker_cluster_access" {
+resource "kafka_acl" "mirror-maker_cluster_access" {
   resource_name                = "kafka-cluster"
   resource_type                = "Cluster"
   acl_principal                = "User:CN=pubsub/mirror-maker"

--- a/dev-aws/kafka-shared-msk/pubsub/mirror-maker.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/mirror-maker.tf
@@ -16,7 +16,7 @@ resource "kafka_acl" "mirror_maker_group_access" {
   acl_permission_type = "Allow"
 }
 
-resource "kafka_acl" "mirror-maker_cluster_access" {
+resource "kafka_acl" "mirror_maker_cluster_access" {
   resource_name                = "kafka-cluster"
   resource_type                = "Cluster"
   acl_principal                = "User:CN=pubsub/mirror-maker"


### PR DESCRIPTION
Set the backend definition directly in the modules

Until now, the backend was defined in the terraform applier CRD. These are removed in this PR: https://github.com/utilitywarehouse/kubernetes-manifests/pull/97392