### PR TITLE
increase retention to allow further testing

### DIFF
--- a/prod-aws/customer-billing/topics.tf
+++ b/prod-aws/customer-billing/topics.tf
@@ -125,8 +125,8 @@ resource "kafka_topic" "replicated-internal-bill-core-model" {
   partitions         = 10
   config = {
     "compression.type" = "zstd"
-    # keep data for 28 days to facilitate invoice-producer v2 work
-    "retention.ms" = "2419200000"
+    # keep data for 35 days to facilitate invoice-producer v2 work
+    "retention.ms" = "3024000000"
     # retain 8GB on each partition
     "retention.bytes" = "8053063680"
     # allow max 100MB for a message


### PR DESCRIPTION
We use this events to be able to validate a big change in our pipeline. The increase from 28 to 35 days means we will have always at least 1 bill run of events on the topic