### PR TITLE
DENA-968: prod: Added backend config for msk modules

### DIFF
--- a/prod-aws/kafka-shared-msk/__env.tf
+++ b/prod-aws/kafka-shared-msk/__env.tf
@@ -1,8 +1,6 @@
 terraform {
   required_version = ">= 1.5.0"
 
-  backend "s3" {}
-
   required_providers {
     kafka = {
       source  = "Mongey/kafka"

--- a/prod-aws/kafka-shared-msk/account-identity/__backend.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-account-identity"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/billing/__backend.tf
+++ b/prod-aws/kafka-shared-msk/billing/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-billing"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/cbc/__backend.tf
+++ b/prod-aws/kafka-shared-msk/cbc/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-cbc"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/contact-channels/__backend.tf
+++ b/prod-aws/kafka-shared-msk/contact-channels/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-contact-channels"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/customer-billing/__backend.tf
+++ b/prod-aws/kafka-shared-msk/customer-billing/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-customer-billing"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/customer-proposition/__backend.tf
+++ b/prod-aws/kafka-shared-msk/customer-proposition/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-customer-proposition"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/customer-support/__backend.tf
+++ b/prod-aws/kafka-shared-msk/customer-support/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-customer-support"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/data-infra/__backend.tf
+++ b/prod-aws/kafka-shared-msk/data-infra/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-data-infra"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/energy-budget-plan/__backend.tf
+++ b/prod-aws/kafka-shared-msk/energy-budget-plan/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-energy-budget-plan"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/iam/__backend.tf
+++ b/prod-aws/kafka-shared-msk/iam/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-iam"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/payment-platform/__backend.tf
+++ b/prod-aws/kafka-shared-msk/payment-platform/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-payment-platform"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/pubsub/__backend.tf
+++ b/prod-aws/kafka-shared-msk/pubsub/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-pubsub"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}

--- a/prod-aws/kafka-shared-msk/workplace-infrastructure/__backend.tf
+++ b/prod-aws/kafka-shared-msk/workplace-infrastructure/__backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "uw-prod-pubsub-tf-applier-state"
+    key     = "prod-aws/kafka-shared-msk-workplace-infrastructure"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}


### PR DESCRIPTION
Set the backend definition directly in the modules

Until now, the backend was defined in the terraform applier CRD. 
These are removed in this PR : https://github.com/utilitywarehouse/kubernetes-manifests/pull/97424