### PR TITLE
Add alias for MSK `tflint` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
         - --hook-config=--delegate-chdir
       exclude: "^.*/kafka-shared-msk/.*$"
     - id: terraform_tflint
+      alias: terraform_tflint_msk
       name: Validate with tflint the MSK team configs
       args:
         - --args=--config=__GIT_WORKING_DIR__/.tflint-msk.hcl


### PR DESCRIPTION
So one can specify just this hook when invoking `pre-commit`, e.g. like:

    pre-commit run --all-files terraform_tflint_msk

So one can run that hook without running the other `tflint` hook over the hosted team configs. This is mostly useful while debugging our internal plugin used with that hook

[1] https://pre-commit.com/#config-alias