### PR TITLE
[BEX-1073] - Create new DQL with different name and retention.

### DIFF
--- a/dev-aws/kafka-shared-msk/customer-billing/modules.tf
+++ b/dev-aws/kafka-shared-msk/customer-billing/modules.tf
@@ -16,11 +16,11 @@ module "fulfilment_router" {
   source           = "../../../modules/tls-app"
   cert_common_name = "customer-billing/fulfilment-router"
   produce_topics   = [kafka_topic.transition_bex_fulfilment_request.name]
-  consume_topics   = [
+  consume_topics = [
     kafka_topic.invoice_fulfillment_deadletter.name,
     kafka_topic.internal_invoice_fulfilment_deadletter.name
   ]
-  consume_groups   = ["bex.fulfilment-router"]
+  consume_groups = ["bex.fulfilment-router"]
 }
 
 module "mail_sender" {

--- a/dev-aws/kafka-shared-msk/customer-billing/modules.tf
+++ b/dev-aws/kafka-shared-msk/customer-billing/modules.tf
@@ -16,7 +16,10 @@ module "fulfilment_router" {
   source           = "../../../modules/tls-app"
   cert_common_name = "customer-billing/fulfilment-router"
   produce_topics   = [kafka_topic.transition_bex_fulfilment_request.name]
-  consume_topics   = [(kafka_topic.invoice_fulfillment_deadletter.name)]
+  consume_topics   = [
+    kafka_topic.invoice_fulfillment_deadletter.name,
+    kafka_topic.internal_invoice_fulfilment_deadletter.name
+  ]
   consume_groups   = ["bex.fulfilment-router"]
 }
 
@@ -45,6 +48,7 @@ module "invoice_fulfillment" {
     kafka_topic.internal_bex_fulfilment_retry_1.name,
     kafka_topic.internal_bex_fulfilment_retry_2.name,
     kafka_topic.invoice_fulfillment_deadletter.name,
+    kafka_topic.internal_invoice_fulfilment_deadletter.name,
     kafka_topic.internal_bex_bill_regeneration_retry_1.name,
     kafka_topic.internal_bex_bill_regeneration_retry_2.name,
     kafka_topic.internal_bex_bill_regeneration_deadletter.name
@@ -59,8 +63,8 @@ module "invoice_fulfillment" {
   ]
   consume_groups = [
     "bex.invoice-fulfillment",
-    "bex.internal.fulfilment-retry-1",
-    "bex.internal.fulfilment-retry-2",
+    "bex.invoice-fulfilment-retry-1",
+    "bex.invoice-fulfilment-retry-2",
     "bex.invoice-fulfillment-regen",
     "bex.invoice-fulfillment-regen-retry-1",
     "bex.invoice-fulfillment-regen-retry-2"

--- a/dev-aws/kafka-shared-msk/customer-billing/topics.tf
+++ b/dev-aws/kafka-shared-msk/customer-billing/topics.tf
@@ -32,6 +32,23 @@ resource "kafka_topic" "invoice_fulfillment_deadletter" {
   }
 }
 
+resource "kafka_topic" "internal_invoice_fulfilment_deadletter" {
+  name               = "bex.internal.fulfilment_deadletter"
+  replication_factor = 3
+  partitions         = 1
+  config = {
+    "remote.storage.enable" = "true"
+    # keep data in hot storage for 1 day
+    "local.retention.ms" = "86400000"
+    # keep data for 28 days
+    "retention.ms" = "2419200000"
+    # allow max 1 MB for a message
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
 resource "kafka_topic" "mail_sender_deadletter" {
   name               = "bex.internal.mail_sender_deadletter"
   replication_factor = 3

--- a/prod-aws/kafka-shared-msk/customer-billing/modules.tf
+++ b/prod-aws/kafka-shared-msk/customer-billing/modules.tf
@@ -16,8 +16,11 @@ module "fulfilment_router" {
   source           = "../../../modules/tls-app"
   cert_common_name = "customer-billing/fulfilment-router"
   produce_topics   = [kafka_topic.transition_bex_fulfilment_request.name]
-  consume_topics   = [(kafka_topic.invoice_fulfillment_deadletter.name)]
-  consume_groups   = ["bex.fulfilment-router"]
+  consume_topics = [
+    kafka_topic.invoice_fulfillment_deadletter.name,
+    kafka_topic.internal_invoice_fulfilment_deadletter.name
+  ]
+  consume_groups = ["bex.fulfilment-router"]
 }
 
 module "mail_sender" {
@@ -45,6 +48,7 @@ module "invoice_fulfillment" {
     kafka_topic.internal_bex_fulfilment_retry_1.name,
     kafka_topic.internal_bex_fulfilment_retry_2.name,
     kafka_topic.invoice_fulfillment_deadletter.name,
+    kafka_topic.internal_invoice_fulfilment_deadletter.name,
     kafka_topic.internal_bex_bill_regeneration_retry_1.name,
     kafka_topic.internal_bex_bill_regeneration_retry_2.name,
     kafka_topic.internal_bex_bill_regeneration_deadletter.name
@@ -59,8 +63,8 @@ module "invoice_fulfillment" {
   ]
   consume_groups = [
     "bex.invoice-fulfillment",
-    "bex.internal.fulfilment-retry-1",
-    "bex.internal.fulfilment-retry-2",
+    "bex.invoice-fulfilment-retry-1",
+    "bex.invoice-fulfilment-retry-2",
     "bex.invoice-fulfillment-regen",
     "bex.invoice-fulfillment-regen-retry-1",
     "bex.invoice-fulfillment-regen-retry-2"

--- a/prod-aws/kafka-shared-msk/customer-billing/topics.tf
+++ b/prod-aws/kafka-shared-msk/customer-billing/topics.tf
@@ -32,6 +32,23 @@ resource "kafka_topic" "invoice_fulfillment_deadletter" {
   }
 }
 
+resource "kafka_topic" "internal_invoice_fulfilment_deadletter" {
+  name               = "bex.internal.fulfilment_deadletter"
+  replication_factor = 3
+  partitions         = 1
+  config = {
+    "remote.storage.enable" = "true"
+    # keep data in hot storage for 1 day
+    "local.retention.ms" = "86400000"
+    # keep data for 28 days
+    "retention.ms" = "2419200000"
+    # allow max 1 MB for a message
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
 resource "kafka_topic" "mail_sender_deadletter" {
   name               = "bex.internal.mail_sender_deadletter"
   replication_factor = 3


### PR DESCRIPTION
 - Old one will be discontinued after k8s manifests changes.
 - rename retry consumer groups to be more consistent.