### PR TITLE
Move existing `tls-apps` to the same module as their topics

### DIFF
--- a/dev-aws/kafka-shared-msk/account-identity/account.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/account.tf
@@ -342,3 +342,17 @@ module "customer_support_crm_idv" {
   consume_topics   = [kafka_topic.account_identity_legacy_account_events.name]
   consume_groups   = ["customer-support.idv.projector-001"]
 }
+
+module "cbc_fraud_detection_consumer" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = [kafka_topic.account_identity_public_account_events.name]
+  consume_groups   = ["account-identity.cbc-fraud-detection-consumer-v1"]
+  cert_common_name = "cbc/cbc-fraud-detection-consumer"
+}
+
+module "cbc_account_events_relay" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = [kafka_topic.account_identity_public_account_events.name]
+  consume_groups   = ["account-identity.cbc-account-events-relay-v2"]
+  cert_common_name = "cbc/cbc-account-events-relay-v2"
+}

--- a/dev-aws/kafka-shared-msk/cbc/cbc.tf
+++ b/dev-aws/kafka-shared-msk/cbc/cbc.tf
@@ -365,8 +365,6 @@ module "cbc_fraud_detection_api" {
 module "cbc_fraud_detection_consumer" {
   source = "../../../modules/tls-app"
   consume_topics = [
-    "auth-customer.iam-credentials-v1-public",
-    "account-identity.public.account.events",
     kafka_topic.FraudEvents.name,
     kafka_topic.lifecycle_events_v2.name,
     kafka_topic.topup_events_v1.name,
@@ -376,7 +374,6 @@ module "cbc_fraud_detection_consumer" {
   produce_topics = [kafka_topic.FraudEvents.name]
   consume_groups = [
     "cbc.cbc-fraud-detection-consumer-v1",
-    "account-identity.cbc-fraud-detection-consumer-v1",
   ]
   cert_common_name = "cbc/cbc-fraud-detection-consumer"
 }
@@ -1301,8 +1298,6 @@ module "cbc_legacy_account_eqdb_loader" {
 module "cbc_account_events_relay" {
   source           = "../../../modules/tls-app"
   produce_topics   = [kafka_topic.legacy_account_events_v2.name]
-  consume_topics   = ["account-identity.public.account.events"]
-  consume_groups   = ["account-identity.cbc-account-events-relay-v2"]
   cert_common_name = "cbc/cbc-account-events-relay-v2"
 }
 

--- a/dev-aws/kafka-shared-msk/iam/iam.tf
+++ b/dev-aws/kafka-shared-msk/iam/iam.tf
@@ -292,3 +292,9 @@ module "castle_processor" {
   consume_topics   = [(kafka_topic.iam_credentials_v1.name)]
   consume_groups   = ["iam.castle-processor"]
 }
+
+module "cbc_fraud_detection_consumer" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = [kafka_topic.iam_credentials_v1_public.name]
+  cert_common_name = "cbc/cbc-fraud-detection-consumer"
+}


### PR DESCRIPTION
So that teams have control over who produces to/consumes from their
topics. This follows on from 859c8b716d44e65733498b8cd67ba63f9304e9e8.
There should be no conflicting resources here, but we'll have to be
careful about applying to avoid deleting any existing ACLs, the plan is:

* `terraform state rm` in the module from which we removed the ACLs, so
  terraform no longer tracks them there
* `terraform apply` in the module we added the ACLs to, this should be a
  no-op as Terraform should detect the ACLs already exist and just add
  them to the state

Ticket: DENA-994