### PR TITLE
Move `tls-app`'s to modules they consume/produce on

### DIFF
--- a/.tflint-msk.hcl
+++ b/.tflint-msk.hcl
@@ -27,7 +27,7 @@ rule "msk_topic_name" {
 
 # Disable this rule until we fix the current issues
 rule "msk_app_topics" {
-  enabled = false
+  enabled = true
 }
 
 # Include module calls

--- a/prod-aws/kafka-shared-msk/account-identity/account.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/account.tf
@@ -313,3 +313,10 @@ module "customer_support_crm_idv" {
   consume_topics   = [kafka_topic.account_identity_legacy_account_events.name]
   consume_groups   = ["customer-support.idv.projector-001"]
 }
+
+module "cbc_fraud_detection_consumer" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = [kafka_topic.account_identity_public_account_events.name]
+  consume_groups   = ["account-identity.cbc-fraud-detection-consumer-v1"]
+  cert_common_name = "cbc/cbc-fraud-detection-consumer"
+}

--- a/prod-aws/kafka-shared-msk/account-identity/legacy_account.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/legacy_account.tf
@@ -282,3 +282,10 @@ module "account_identity_legacy_to_unified" {
   produce_topics   = [kafka_topic.account_identity_account_unified_events.name]
   cert_common_name = "account-platform/legacy_to_unified"
 }
+
+module "cbc_account_events_relay" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = [kafka_topic.account_identity_legacy_account_events.name]
+  consume_groups   = ["account-identity.cbc-account-events-relay-v2"]
+  cert_common_name = "cbc/cbc-account-events-relay-v2"
+}

--- a/prod-aws/kafka-shared-msk/cbc/cbc.tf
+++ b/prod-aws/kafka-shared-msk/cbc/cbc.tf
@@ -31,16 +31,8 @@ module "cbc_data_infra_exporter" {
 }
 
 module "cbc_fraud_detection_consumer" {
-  source = "../../../modules/tls-app"
-  consume_topics = [
-    "auth-customer.iam-credentials-v1-public",
-    "account-identity.public.account.events",
-  ]
-  produce_topics = []
-  consume_groups = [
-    "cbc.cbc-fraud-detection-consumer-v1",
-    "account-identity.cbc-fraud-detection-consumer-v1",
-  ]
+  source           = "../../../modules/tls-app"
+  consume_groups   = ["cbc.cbc-fraud-detection-consumer-v1"]
   cert_common_name = "cbc/cbc-fraud-detection-consumer"
 }
 
@@ -51,12 +43,4 @@ module "cbc_events_indexer" {
   ]
   consume_groups   = ["cbc.cbc-events-indexer"]
   cert_common_name = "cbc/cbc-events-indexer"
-}
-
-module "cbc_account_events_relay" {
-  source           = "../../../modules/tls-app"
-  produce_topics   = []
-  consume_topics   = ["account-identity.legacy.account.events"]
-  consume_groups   = ["account-identity.cbc-account-events-relay-v2"]
-  cert_common_name = "cbc/cbc-account-events-relay-v2"
 }

--- a/prod-aws/kafka-shared-msk/iam/iam.tf
+++ b/prod-aws/kafka-shared-msk/iam/iam.tf
@@ -291,3 +291,9 @@ module "castle_processor" {
   consume_topics   = [(kafka_topic.iam_credentials_v1.name)]
   consume_groups   = ["iam.castle-processor"]
 }
+
+module "cbc_fraud_detection_consumer" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = [kafka_topic.iam_credentials_v1_public.name]
+  cert_common_name = "cbc/cbc-fraud-detection-consumer"
+}


### PR DESCRIPTION
- Move `tls-app`'s to modules they consume/produce on

    This is the same thing as cd7c0f097ab7fc6cedd48a93a70a9ccae27ee7e2 but
    for prod. This charge similarly needs some manually `terraform apply`ing
    before merge to avoid potential deleting ACLs

- Enable MSK topic checking tflint pluin rule

    With the previous commit, there should be no offending modules in this
    repo, so enable the rule to keep it that way.

Ticket:  DENA-994
