### PR TITLE
DENA-991: account-identity dev: have a single tls-app module per cert-common-name

### DIFF
--- a/dev-aws/kafka-shared-msk/account-identity/account.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/account.tf
@@ -356,7 +356,10 @@ module "cbc_fraud_detection_consumer" {
 
 module "cbc_account_events_relay" {
   source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.account_identity_public_account_events.name]
+  consume_topics   = [
+    kafka_topic.account_identity_public_account_events.name,
+    kafka_topic.account_identity_legacy_account_events.name
+  ]
   consume_groups   = ["account-identity.cbc-account-events-relay-v2"]
   cert_common_name = "cbc/cbc-account-events-relay-v2"
 }

--- a/dev-aws/kafka-shared-msk/account-identity/exceptions.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/exceptions.tf
@@ -265,10 +265,3 @@ module "account_identity_supply_address_debt_checker" {
   produce_topics   = [kafka_topic.account_identity_account_exceptions_v1.name]
   cert_common_name = "account-platform/supply_address_debt_checker"
 }
-
-module "account_identity_exceptions_uswitch_reporter" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.account_identity_account_exceptions_events.name]
-  consume_groups   = ["account-identity.uswitch-reporter"]
-  cert_common_name = "customer-proposition/uswitch-reporter-account-consumer"
-}

--- a/dev-aws/kafka-shared-msk/account-identity/legacy_account.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/legacy_account.tf
@@ -130,13 +130,6 @@ resource "kafka_topic" "account_identity_legacy_account_eqdb_events" {
   replication_factor = 3
 }
 
-module "cbc_account_events_relay_v2" {
-  source           = "../../../modules/tls-app"
-  consume_groups   = ["account-identity.cbc-account-events-relay-v2"]
-  consume_topics   = [kafka_topic.account_identity_legacy_account_events.name]
-  cert_common_name = "cbc/cbc-account-events-relay-v2"
-}
-
 module "account_identity_created_to_unified" {
   source           = "../../../modules/tls-app"
   consume_topics   = [kafka_topic.account_identity_legacy_account_events.name, kafka_topic.account_identity_account_events_v2.name]
@@ -266,7 +259,10 @@ module "account_identity_holders_mapper" {
 
 module "account_identity_legacy_acount_change_event_uswitch_reporter" {
   source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.account_identity_legacy_account_change_events_compacted.name]
+  consume_topics   = [
+    kafka_topic.account_identity_legacy_account_change_events_compacted.name,
+    kafka_topic.account_identity_account_exceptions_events.name
+  ]
   consume_groups   = ["account-identity.uswitch-reporter"]
   cert_common_name = "customer-proposition/uswitch-reporter-account-consumer"
 }


### PR DESCRIPTION
See ticket for explanations: https://linear.app/utilitywarehouse/issue/DENA-991/kafka-config-validate-tls-app-cert-common-name-is-unique-in-a-module