### PR TITLE
DENA-991: prod account-identity: have a single tls-app module per cert-common-name

### DIFF
--- a/prod-aws/kafka-shared-msk/account-identity/exceptions.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/exceptions.tf
@@ -132,13 +132,6 @@ module "account_identity_land_registry_indexer" {
   cert_common_name = "account-platform/land_registry_indexer"
 }
 
-module "account_identity_exceptions_uswitch_reporter" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.account_identity_account_exceptions_events.name]
-  consume_groups   = ["account-identity.uswitch-reporter"]
-  cert_common_name = "customer-proposition/uswitch-reporter-account-consumer"
-}
-
 module "account_identity_exceptions_processor" {
   source           = "../../../modules/tls-app"
   consume_topics   = [kafka_topic.account_identity_account_exceptions_v1.name]

--- a/prod-aws/kafka-shared-msk/account-identity/holders.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/holders.tf
@@ -23,9 +23,9 @@ module "account_identity_update_holders" {
 }
 
 module "account_identity_holders_mapper" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.account_identity_legacy_account_events.name]
-  consume_groups   = [
+  source         = "../../../modules/tls-app"
+  consume_topics = [kafka_topic.account_identity_legacy_account_events.name]
+  consume_groups = [
     "account-identity.account-holders-mapper",
     "account-identity.account-holders-mapper-data-fix"
   ]

--- a/prod-aws/kafka-shared-msk/account-identity/holders.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/holders.tf
@@ -25,15 +25,10 @@ module "account_identity_update_holders" {
 module "account_identity_holders_mapper" {
   source           = "../../../modules/tls-app"
   consume_topics   = [kafka_topic.account_identity_legacy_account_events.name]
-  consume_groups   = ["account-identity.account-holders-mapper"]
-  produce_topics   = [kafka_topic.account_identity_legacy_account_events.name]
-  cert_common_name = "account-platform/holders_mapper"
-}
-
-module "account_identity_holders_mapper_data_fix" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.account_identity_legacy_account_events.name]
-  consume_groups   = ["account-identity.account-holders-mapper-data-fix"]
+  consume_groups   = [
+    "account-identity.account-holders-mapper",
+    "account-identity.account-holders-mapper-data-fix"
+  ]
   produce_topics   = [kafka_topic.account_identity_legacy_account_events.name]
   cert_common_name = "account-platform/holders_mapper"
 }

--- a/prod-aws/kafka-shared-msk/account-identity/legacy_account.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/legacy_account.tf
@@ -194,8 +194,8 @@ module "account_identity_private_legacy_account_indexer" {
 }
 
 module "account_identity_legacy_account_change_event_uswitch_reporter" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [
+  source = "../../../modules/tls-app"
+  consume_topics = [
     kafka_topic.account_identity_legacy_account_change_events_compacted.name,
     kafka_topic.account_identity_account_exceptions_events.name
   ]

--- a/prod-aws/kafka-shared-msk/account-identity/legacy_account.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/legacy_account.tf
@@ -195,7 +195,10 @@ module "account_identity_private_legacy_account_indexer" {
 
 module "account_identity_legacy_account_change_event_uswitch_reporter" {
   source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.account_identity_legacy_account_change_events_compacted.name]
+  consume_topics   = [
+    kafka_topic.account_identity_legacy_account_change_events_compacted.name,
+    kafka_topic.account_identity_account_exceptions_events.name
+  ]
   consume_groups   = ["account-identity.uswitch-reporter"]
   cert_common_name = "customer-proposition/uswitch-reporter-account-consumer"
 }


### PR DESCRIPTION
See ticket for explanations: https://linear.app/utilitywarehouse/issue/DENA-991/kafka-config-validate-tls-app-cert-common-name-is-unique-in-a-module

For safety, before applying, I'll remove from the state the ones that are set to be destroyed