### PR TITLE
DENA-991: workplace-infrastructure: have a single tls-app module per cert-common-name

### DIFF
--- a/prod-aws/kafka-shared-msk/workplace-infrastructure/netapp-audit.tf
+++ b/prod-aws/kafka-shared-msk/workplace-infrastructure/netapp-audit.tf
@@ -28,26 +28,15 @@ module "workplace_infrastructure_netapp_audit_publish_to_kafka_svm_cifs_a" {
   source = "../../../modules/tls-app"
   consume_topics = [
     kafka_topic.workplace_infrastructure_netapp_audit_v1_svm_cifs_a.name,
-  ]
-  consume_groups = [
-    "workplace-infrastructure.netapp-audit-v1.svm-cifs-a.consumer"
-  ]
-  produce_topics = [
-    kafka_topic.workplace_infrastructure_netapp_audit_v1_svm_cifs_a.name,
-  ]
-  cert_common_name = "corp-netapp-audit/netapp-audit-publish-to-kafka"
-}
-
-module "workplace_infrastructure_netapp_audit_publish_to_kafka_svm_cifs_b" {
-  source = "../../../modules/tls-app"
-  consume_topics = [
     kafka_topic.workplace_infrastructure_netapp_audit_v1_svm_cifs_b.name,
   ]
   consume_groups = [
+    "workplace-infrastructure.netapp-audit-v1.svm-cifs-a.consumer",
     "workplace-infrastructure.netapp-audit-v1.svm-cifs-b.consumer"
   ]
   produce_topics = [
-    kafka_topic.workplace_infrastructure_netapp_audit_v1_svm_cifs_b.name,
+    kafka_topic.workplace_infrastructure_netapp_audit_v1_svm_cifs_a.name,
+    kafka_topic.workplace_infrastructure_netapp_audit_v1_svm_cifs_b.name
   ]
   cert_common_name = "corp-netapp-audit/netapp-audit-publish-to-kafka"
 }


### PR DESCRIPTION
See ticket for explanations: https://linear.app/utilitywarehouse/issue/DENA-991/kafka-config-validate-tls-app-cert-common-name-is-unique-in-a-module

For safety, before applying, I'll remove from the state the ones that are set to be destroyed