### PR TITLE
DENA-671: Enable remote storage for account-identity.public.account.events in dev

### DIFF
--- a/dev-aws/kafka-shared-msk/account-identity/account.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/account.tf
@@ -74,6 +74,10 @@ resource "kafka_topic" "account_identity_public_account_events" {
     "compression.type" = "zstd"
     # infinite retention
     "retention.ms" = "-1"
+    # keep data in hot storage for 1 day
+    "local.retention.ms" = "86400000"
+    # enable remote storage
+    "remote.storage.enable" = "true"
   }
   name               = "account-identity.public.account.events"
   partitions         = 15


### PR DESCRIPTION
This was picked up by the validation rule that I'm currently working on.