### PR TITLE
DENA-671: prod: Remove retention time from compacted topics

### DIFF
--- a/prod-aws/kafka-shared-msk/account-identity/account.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/account.tf
@@ -35,9 +35,7 @@ resource "kafka_topic" "account_identity_account_unified_events" {
     "cleanup.policy" = "compact"
     # compaction lag of 7 days
     "max.compaction.lag.ms" = "604800000"
-    # infinite retention
-    "retention.ms"     = "-1"
-    "compression.type" = "zstd"
+    "compression.type"      = "zstd"
   }
   name               = "account-identity.account.unified.events"
   partitions         = 50

--- a/prod-aws/kafka-shared-msk/account-identity/exceptions.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/exceptions.tf
@@ -21,8 +21,6 @@ resource "kafka_topic" "account_identity_account_exceptions_events" {
 
     # compaction lag of 7 days
     "max.compaction.lag.ms" = "604800000"
-    # infinite retention
-    "retention.ms" = "-1"
   }
   name               = "account-identity.account.exceptions.events"
   partitions         = 15

--- a/prod-aws/kafka-shared-msk/account-identity/finance.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/finance.tf
@@ -4,8 +4,6 @@ resource "kafka_topic" "account_identity_finance_events_compacted" {
     "compression.type" = "zstd"
     # compaction lag of 7 days
     "max.compaction.lag.ms" = "604800000"
-    # infinite retention
-    "retention.ms" = "-1"
   }
   name               = "account-identity.finance.events.compacted"
   partitions         = 15

--- a/prod-aws/kafka-shared-msk/account-identity/holders.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/holders.tf
@@ -4,8 +4,6 @@ resource "kafka_topic" "account_identity_legacy_account_holder_events_compacted"
   partitions         = 15
   config = {
     "compression.type" = "zstd"
-    # infinite retention
-    "retention.ms" = "-1"
     # compaction lag of 7 days
     "max.compaction.lag.ms" = "604800000"
     # allow max 1 MB for a message

--- a/prod-aws/kafka-shared-msk/account-identity/legacy_account.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/legacy_account.tf
@@ -5,8 +5,6 @@ resource "kafka_topic" "account_identity_legacy_account_events_compacted" {
     "compression.type" = "zstd"
     # compaction lag of 7 days
     "max.compaction.lag.ms" = "604800000"
-    # infinite retention
-    "retention.ms" = "-1"
   }
   name               = "account-identity.legacy.account.events.compacted"
   partitions         = 50
@@ -20,8 +18,7 @@ resource "kafka_topic" "account_identity_legacy_account_changelog_events" {
 
     # compaction lag of 7 days
     "max.compaction.lag.ms" = "604800000"
-    # infinite retention
-    "retention.ms" = "-1"
+
   }
   name               = "account-identity.legacy.account.changelog.events"
   partitions         = 15
@@ -49,9 +46,7 @@ resource "kafka_topic" "account_identity_legacy_account_change_events_compacted"
     "cleanup.policy" = "compact"
     # compaction lag of 7 days
     "max.compaction.lag.ms" = "604800000"
-    # infinite retention
-    "retention.ms"     = "-1"
-    "compression.type" = "zstd"
+    "compression.type"      = "zstd"
   }
   name               = "account-identity.legacy.account.change.events.compacted"
   partitions         = 50
@@ -67,9 +62,7 @@ resource "kafka_topic" "account_identity_legacy_account_braze_events_compacted" 
     "cleanup.policy" = "compact"
     # compaction lag of 7 days
     "max.compaction.lag.ms" = "604800000"
-    # infinite retention
-    "retention.ms"     = "-1"
-    "compression.type" = "zstd"
+    "compression.type"      = "zstd"
   }
   name               = "account-identity.legacy.account.braze.events.compacted"
   partitions         = 50
@@ -81,9 +74,7 @@ resource "kafka_topic" "account_identity_internal_legacy_account_events" {
     "cleanup.policy" = "compact"
     # compaction lag of 7 days
     "max.compaction.lag.ms" = "604800000"
-    # infinite retention
-    "retention.ms"     = "-1"
-    "compression.type" = "zstd"
+    "compression.type"      = "zstd"
   }
   name               = "account-identity.internal.legacy.account.events"
   partitions         = 15


### PR DESCRIPTION
Retention time is irrelevant for compacted topics.
See https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#retention-ms