### PR TITLE
DENA-671: Unify comments for bytes properties

### DIFF
--- a/dev-aws/kafka-shared-msk/customer-proposition/customer-proposition.tf
+++ b/dev-aws/kafka-shared-msk/customer-proposition/customer-proposition.tf
@@ -48,11 +48,11 @@ resource "kafka_topic" "service_status_v3" {
   # infinte retention
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
     "retention.ms"          = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
-    # allow max 1 MB for a message
+    # allow for a batch of records maximum 1MiB
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"


### PR DESCRIPTION
These were added since I created the [initial unification PR,](https://github.com/utilitywarehouse/kafka-cluster-config/pull/678) so fixing them too