### PR TITLE
Bump our `tflint` plugin

### DIFF
--- a/.semgrep/rules.yaml
+++ b/.semgrep/rules.yaml
@@ -10,3 +10,8 @@ rules:
     message: "TLS apps in the MSK configuration must be defined the module they produce/consume on"
     languages: [terraform]
     severity: ERROR
+  - id: enforce-msk-app-consume-groups
+    pattern-regex: tflint-ignore.*msk_app_consume_groups
+    message: "TLS apps in the MSK configuration must prefix all consume_groups with the team name"
+    languages: [terraform]
+    severity: ERROR

--- a/.tflint-msk.hcl
+++ b/.tflint-msk.hcl
@@ -8,7 +8,7 @@ plugin "terraform" {
 plugin "uw-kafka-config" {
   enabled = true
 
-  version = "1.9.0"
+  version = "1.10.0"
   source  = "github.com/utilitywarehouse/tflint-ruleset-kafka-config"
 }
 


### PR DESCRIPTION
To bring in the latest release[1]. Also make the new rule non-ignorable,
since there's no good reason to not prefix the consumer group names

Link: https://github.com/utilitywarehouse/tflint-ruleset-kafka-config/releases/tag/v1.10.0 [1]