### PR TITLE
msk/account-identity: add new topic for verification dpds

### DIFF
--- a/dev-aws/kafka-shared-msk/account-identity/dpd.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/dpd.tf
@@ -1,0 +1,26 @@
+resource "kafka_topic" "account_identity_dpd_v1" {
+  name               = "auth-customer.account-identity-dpd-v1"
+  replication_factor = 3
+  partitions         = 1
+  config = {
+    # Use tiered storage
+    "remote.storage.enable" = "true"
+    # keep on each partition 100MiB
+    "retention.bytes" = "104857600"
+    # keep data for 7 days
+    "retention.ms" = "604800000"
+    # keep data in primary storage for 2 days
+    "local.retention.ms" = "172800000"
+    # allow for a batch of records maximum 1MiB
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+# Existing iam dpd mapper config is in ../iam/iam.tf
+module "iam_dpd_mapper" {
+  source           = "../../../modules/tls-app"
+  produce_topics   = [kafka_topic.account_identity_dpd_v1.name]
+  cert_common_name = "auth-customer/dpd-mapper"
+}


### PR DESCRIPTION
Existing DPD topic defined [here](https://github.com/utilitywarehouse/kafka-cluster-config/blob/d94ec646323a088ebc5bfcd54e5a258bbad213a1/dev-aws/kafka-shared-msk/iam/iam.tf#L77-L95) - not sure if we want to define a new one for the verification events or reuse it. If we define a new one we could also make the naming more explicit, e.g. `account_identity_verification_dpd_v1`