### PR TITLE
Put quota in place for Mirror Maker as it drives the CPU high

### DIFF
--- a/prod-aws/kafka-shared-msk/pubsub/mirror-maker.tf
+++ b/prod-aws/kafka-shared-msk/pubsub/mirror-maker.tf
@@ -27,3 +27,15 @@ resource "kafka_acl" "mirror_maker_cluster_access" {
 
   depends_on = [kafka_acl.tf_applier_cluster]
 }
+
+resource "kafka_quota" "mirror_maker_quota" {
+  entity_name = "User:CN=pubsub/mirror-maker"
+  entity_type = "user"
+  config = {
+    # limit producing to 5 MB/s/broker
+    "producer_byte_rate" = "5242880"
+
+    # Allow 100% of CPU. More on this here: https://docs.confluent.io/kafka/design/quotas.html#request-rate-quotas
+    "request_percentage" = "100"
+  }
+}


### PR DESCRIPTION
Context: cbc is mirroring a big topic and this drives the CPU high in MSK https://grafana.prod.aws.uw.systems/d/rrE2HgHVz/msk-kafka-metrics?orgId=1&refresh=30s