### PR TITLE
Revert "dev/cbc: remove customer-api lifecycle permissions for metric test"

### DIFF
--- a/dev-aws/kafka-shared-msk/cbc/cbc.tf
+++ b/dev-aws/kafka-shared-msk/cbc/cbc.tf
@@ -1068,6 +1068,7 @@ module "cbc_dispute_credits_projector" {
 module "cbc_customer_api" {
   source = "../../../modules/tls-app"
   produce_topics = [
+    kafka_topic.lifecycle_events_v2.name,
     kafka_topic.customer_events_v1.name
   ]
   cert_common_name = "cbc/cbc-customer-api"


### PR DESCRIPTION
Reverts utilitywarehouse/kafka-cluster-config#705