### PR TITLE
msk/account-identity: Add moved block to properly fix typo

### DIFF
--- a/dev-aws/kafka-shared-msk/account-identity/account.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/account.tf
@@ -132,6 +132,11 @@ resource "kafka_topic" "account_identity_account_bill_writes_public" {
   replication_factor = 3
 }
 
+moved {
+  from = kafka_topic.account_identity_accunt_bill_writes_public
+  to   = kafka_topic.account_identity_account_bill_writes_public
+}
+
 module "account_identity_account_atomic_v1_indexer" {
   source           = "../../../modules/tls-app"
   consume_topics   = [kafka_topic.account_identity_account_atomic_v1.name]

--- a/prod-aws/kafka-shared-msk/account-identity/account.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/account.tf
@@ -152,6 +152,11 @@ resource "kafka_topic" "account_identity_account_bill_writes_public" {
   replication_factor = 3
 }
 
+moved {
+  from = kafka_topic.account_identity_accunt_bill_writes_public
+  to   = kafka_topic.account_identity_account_bill_writes_public
+}
+
 module "account_identity_account_api_account_atomic_producer" {
   source           = "../../../modules/tls-app"
   produce_topics   = [kafka_topic.account_identity_account_atomic_v1.name]


### PR DESCRIPTION
some [slack context](https://utilitywarehouse.slack.com/archives/C0337K04DTP/p1734085584032149)