### PR TITLE
chore: DENA-424 - add config for kafka connect

### DIFF
--- a/dev-aws/kafka-shared-msk/account-identity/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/kafka-connect.tf
@@ -1,0 +1,6 @@
+module "kafka_connect_read_legacy_account_events" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = ["account-identity.legacy.account.events"]
+  consume_groups   = ["kafka-connect-group"]
+  cert_common_name = "dev-enablement/kafka-connect"
+}

--- a/dev-aws/kafka-shared-msk/account-identity/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/kafka-connect.tf
@@ -1,6 +1,6 @@
 module "kafka_connect_read_legacy_account_events" {
   source           = "../../../modules/tls-app"
   consume_topics   = ["account-identity.legacy.account.events"]
-  consume_groups   = ["kafka-connect-group"]
+  consume_groups   = ["dev-enablement.kafka-connect-group"]
   cert_common_name = "dev-enablement/kafka-connect"
 }

--- a/dev-aws/kafka-shared-msk/customer-proposition/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/customer-proposition/kafka-connect.tf
@@ -1,6 +1,6 @@
 module "kafka_connect_read_service_status_events" {
   source           = "../../../modules/tls-app"
   consume_topics   = ["customer-proposition.service-status.events.v3"]
-  consume_groups   = ["kafka-connect-group"]
+  consume_groups   = ["dev-enablement.kafka-connect-group"]
   cert_common_name = "dev-enablement/kafka-connect"
 }

--- a/dev-aws/kafka-shared-msk/customer-proposition/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/customer-proposition/kafka-connect.tf
@@ -1,0 +1,6 @@
+module "kafka_connect_read_service_status_events" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = ["customer-proposition.service-status.events.v3"]
+  consume_groups   = ["kafka-connect-group"]
+  cert_common_name = "dev-enablement/kafka-connect"
+}

--- a/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
@@ -1,0 +1,69 @@
+# https://docs.confluent.io/platform/7.8/connect/references/allconfigs.html#distributed-worker-configuration
+resource "kafka_topic" "_connect_configs" {
+  name               = "_connect-configs"
+  partitions         = 1
+  replication_factor = 3
+
+  config = {
+    "cleanup.policy"       = "compact"
+    "compression.type"     = "zstd"
+    "retention.ms"         = "-1"
+  }
+}
+
+resource "kafka_topic" "_connect_offsets" {
+  name               = "_connect-offsets"
+  partitions         = 25
+  replication_factor = 3
+
+  config = {
+    "cleanup.policy"       = "compact"
+    "compression.type"     = "zstd"
+    "retention.ms"         = "-1"
+  }
+}
+
+resource "kafka_topic" "_connect_status" {
+  name               = "_connect-status"
+  partitions         = 5
+  replication_factor = 3
+
+  config = {
+    "cleanup.policy"       = "compact"
+    "compression.type"     = "zstd"
+    "retention.ms"         = "-1"
+  }
+}
+
+
+# https://docs.confluent.io/platform/7.8/connect/security.html#worker-acl-requirements
+
+# Allow Kafka Connect full access to internal topics
+resource "kafka_acl" "kafka_connect_full_internal_topics" {
+  resource_name       = "_connect-*"
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=dev-enablement/kafka-connect"
+  acl_host            = "*"
+  acl_operation       = "All"
+  acl_permission_type = "Allow"
+}
+
+# Allow Kafka Connect to consume only on other topics
+resource "kafka_acl" "kafka_connect_consume_other_topics" {
+  resource_name       = "*"
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=dev-enablement/kafka-connect"
+  acl_host            = "*"
+  acl_operation       = "Read"
+  acl_permission_type = "Allow"
+}
+
+# Needs read/write to register itself as a consumer group
+resource "kafka_acl" "kafka_connect_group_acl" {
+  resource_name       = "*"
+  resource_type       = "Group"
+  acl_principal       = "User:CN=dev-enablement/kafka-connect"
+  acl_host            = "*"
+  acl_operation       = "All"
+  acl_permission_type = "Allow"
+}

--- a/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
@@ -1,37 +1,37 @@
 # https://docs.confluent.io/platform/7.8/connect/references/allconfigs.html#distributed-worker-configuration
-resource "kafka_topic" "_connect_configs" {
-  name               = "_connect-configs"
+resource "kafka_topic" "connect_configs" {
+  name               = "dev-enablement.connect-configs"
   partitions         = 1
   replication_factor = 3
 
   config = {
-    "cleanup.policy"    = "compact"
-    "compression.type"  = "zstd"
-    "retention.ms"      = "-1"
+    "cleanup.policy"   = "compact"
+    "compression.type" = "zstd"
+
   }
 }
 
-resource "kafka_topic" "_connect_offsets" {
-  name               = "_connect-offsets"
+resource "kafka_topic" "connect_offsets" {
+  name               = "dev-enablement.connect-offsets"
   partitions         = 25
   replication_factor = 3
 
   config = {
-    "cleanup.policy"    = "compact"
-    "compression.type"  = "zstd"
-    "retention.ms"      = "-1"
+    "cleanup.policy"   = "compact"
+    "compression.type" = "zstd"
+
   }
 }
 
-resource "kafka_topic" "_connect_status" {
-  name               = "_connect-status"
+resource "kafka_topic" "connect_status" {
+  name               = "dev-enablement.connect-status"
   partitions         = 5
   replication_factor = 3
 
   config = {
-    "cleanup.policy"    = "compact"
-    "compression.type"  = "zstd"
-    "retention.ms"      = "-1"
+    "cleanup.policy"   = "compact"
+    "compression.type" = "zstd"
+
   }
 }
 

--- a/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
@@ -42,6 +42,6 @@ resource "kafka_topic" "connect_status" {
 module "kafka_connect_full_internal_topics" {
   source           = "../../../modules/tls-app"
   consume_topics   = ["dev-enablement.connect-configs", "dev-enablement.connect-offsets", "dev-enablement.connect-status"]
-  consume_groups   = ["kafka-connect-group"]
+  consume_groups   = ["dev-enablement.kafka-connect-group"]
   cert_common_name = "dev-enablement/kafka-connect"
 }

--- a/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
@@ -5,9 +5,9 @@ resource "kafka_topic" "_connect_configs" {
   replication_factor = 3
 
   config = {
-    "cleanup.policy"       = "compact"
-    "compression.type"     = "zstd"
-    "retention.ms"         = "-1"
+    "cleanup.policy"    = "compact"
+    "compression.type"  = "zstd"
+    "retention.ms"      = "-1"
   }
 }
 
@@ -17,9 +17,9 @@ resource "kafka_topic" "_connect_offsets" {
   replication_factor = 3
 
   config = {
-    "cleanup.policy"       = "compact"
-    "compression.type"     = "zstd"
-    "retention.ms"         = "-1"
+    "cleanup.policy"    = "compact"
+    "compression.type"  = "zstd"
+    "retention.ms"      = "-1"
   }
 }
 
@@ -29,9 +29,9 @@ resource "kafka_topic" "_connect_status" {
   replication_factor = 3
 
   config = {
-    "cleanup.policy"       = "compact"
-    "compression.type"     = "zstd"
-    "retention.ms"         = "-1"
+    "cleanup.policy"    = "compact"
+    "compression.type"  = "zstd"
+    "retention.ms"      = "-1"
   }
 }
 

--- a/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
@@ -39,31 +39,9 @@ resource "kafka_topic" "connect_status" {
 # https://docs.confluent.io/platform/7.8/connect/security.html#worker-acl-requirements
 
 # Allow Kafka Connect full access to internal topics
-resource "kafka_acl" "kafka_connect_full_internal_topics" {
-  resource_name       = "_connect-*"
-  resource_type       = "Topic"
-  acl_principal       = "User:CN=dev-enablement/kafka-connect"
-  acl_host            = "*"
-  acl_operation       = "All"
-  acl_permission_type = "Allow"
-}
-
-# Allow Kafka Connect to consume only on other topics
-resource "kafka_acl" "kafka_connect_consume_other_topics" {
-  resource_name       = "*"
-  resource_type       = "Topic"
-  acl_principal       = "User:CN=dev-enablement/kafka-connect"
-  acl_host            = "*"
-  acl_operation       = "Read"
-  acl_permission_type = "Allow"
-}
-
-# Needs read/write to register itself as a consumer group
-resource "kafka_acl" "kafka_connect_group_acl" {
-  resource_name       = "*"
-  resource_type       = "Group"
-  acl_principal       = "User:CN=dev-enablement/kafka-connect"
-  acl_host            = "*"
-  acl_operation       = "All"
-  acl_permission_type = "Allow"
+module "kafka_connect_full_internal_topics" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = ["dev-enablement.connect-configs", "dev-enablement.connect-offsets", "dev-enablement.connect-status"]
+  consume_groups   = ["kafka-connect-group"]
+  cert_common_name = "dev-enablement/kafka-connect"
 }


### PR DESCRIPTION
Using kafka connect to consume from particular topics
* `customer-proposition.service-status.events.v3` - for account to service(s) mapping
* `account-identity.legacy.account.events` - for denormalising the account model