### PR TITLE
Rename Grafana Cloud collector app

### DIFF
--- a/dev-aws/otel/otel.tf
+++ b/dev-aws/otel/otel.tf
@@ -68,9 +68,9 @@ module "otel_tail_sampling_collector" {
   cert_common_name = "otel/tail-sampling-collector"
 }
 
-module "otel_goc_forwarding_collector" {
+module "otel_gc_forwarding_collector" {
   source           = "../../modules/tls-app"
   consume_topics   = [kafka_topic.otlp_sampled_spans.name]
-  consume_groups   = ["otel.goc-forwarding-collector"]
-  cert_common_name = "otel/goc-forwarding-collector"
+  consume_groups   = ["otel.gc-forwarding-collector"]
+  cert_common_name = "otel/gc-forwarding-collector"
 }


### PR DESCRIPTION
I keep using GoC (Grafana on Call) when I mean to be referring to Grafana Cloud (gc)

Ticket: DENA-1238