### PR TITLE
Revert "Add app for OTEL GoC collector"

### DIFF
--- a/dev-aws/otel/otel.tf
+++ b/dev-aws/otel/otel.tf
@@ -67,10 +67,3 @@ module "otel_tail_sampling_collector" {
   consume_groups   = ["otel.tail-sampling-collector"]
   cert_common_name = "otel/tail-sampling-collector"
 }
-
-module "otel_gc_forwarding_collector" {
-  source           = "../../modules/tls-app"
-  consume_topics   = [kafka_topic.otlp_sampled_spans.name]
-  consume_groups   = ["otel.gc-forwarding-collector"]
-  cert_common_name = "otel/gc-forwarding-collector"
-}

--- a/prod-aws/otel/otel.tf
+++ b/prod-aws/otel/otel.tf
@@ -68,10 +68,3 @@ module "otel_tail_sampling_collector" {
   consume_groups   = ["otel.tail-sampling-collector"]
   cert_common_name = "otel/tail-sampling-collector"
 }
-
-module "otel_gc_forwarding_collector" {
-  source           = "../../modules/tls-app"
-  consume_topics   = [kafka_topic.otlp_sampled_spans.name]
-  consume_groups   = ["otel.gc-forwarding-collector"]
-  cert_common_name = "otel/gc-forwarding-collector"
-}


### PR DESCRIPTION
We're no longer using the additional collector, so drop these Kafka resources. This reverts commits

* 76ff931e9ea2c4b4d4e2cf8b7042b873e60d99e5.
* 4541a2992e84633f3d02f3292ca30eca4b30ddab
* 6454ecce0c4fa7e1d11a3375ca7147a06e7d506c

Ticket: DENA-1117