### PR TITLE
[EXP-952] correct consumer group id

### DIFF
--- a/prod-aws/kafka-shared-msk/energy-platform/energy-platform.tf
+++ b/prod-aws/kafka-shared-msk/energy-platform/energy-platform.tf
@@ -72,6 +72,6 @@ module "crm_adapter" {
 module "bill_reads_producer_projector" {
   source           = "../../../modules/tls-app"
   consume_topics   = [kafka_topic.meter_reads.name]
-  consume_groups   = ["energy-platform.bill-reads-producer-projector"]
+  consume_groups   = ["energy-platform.bill-reads-producer"]
   cert_common_name = "energy-platform/bill-reads-producer-projector"
 }


### PR DESCRIPTION
This consumer group has different id in prod and in dev. Correcting the prod one.