### PR TITLE
Allow another consumer group for parquet backup

### DIFF
--- a/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
@@ -43,7 +43,7 @@ module "kafka_connect_full_internal_topics" {
   source           = "../../../modules/tls-app"
   consume_topics   = ["dev-enablement.connect-configs", "dev-enablement.connect-offsets", "dev-enablement.connect-status", "dev-enablement.msk-backup-source1", "dev-enablement.msk-backup-source2"]
   produce_topics   = ["dev-enablement.connect-configs", "dev-enablement.connect-offsets", "dev-enablement.connect-status", "dev-enablement.msk-backup-target1", "dev-enablement.restore.customer-proposition.service-status.events.v3"]
-  consume_groups   = ["dev-enablement.kafka-connect-group", "dev-enablement.kafka-connect-worker-group", "dev-enablement.kafka-connect-backup-all"]
+  consume_groups   = ["dev-enablement.kafka-connect-group", "dev-enablement.kafka-connect-worker-group", "dev-enablement.kafka-connect-backup-all", "dev-enablement.kafka-connect-backup-parquet-select"]
   cert_common_name = "dev-enablement/kafka-connect"
 }
 


### PR DESCRIPTION
Use another consumer group for backing up as parquet