### PR TITLE
Reduce the number of partitions, as we're not running a big kafka-connect cluster

### DIFF
--- a/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/dev-enablement/kafka-connect.tf
@@ -13,7 +13,7 @@ resource "kafka_topic" "connect_configs" {
 
 resource "kafka_topic" "connect_offsets" {
   name               = "dev-enablement.connect-offsets"
-  partitions         = 25
+  partitions         = 1
   replication_factor = 3
 
   config = {
@@ -25,7 +25,7 @@ resource "kafka_topic" "connect_offsets" {
 
 resource "kafka_topic" "connect_status" {
   name               = "dev-enablement.connect-status"
-  partitions         = 5
+  partitions         = 1
   replication_factor = 3
 
   config = {


### PR DESCRIPTION
Both topics should be safe to recreate:
- dev-enablement.connect-offsets: these hold only offsets from Sources, and we don't have any atm -- I used some for testing S3 restores
- dev-enablement.connect-status: these hold the topic status -> the messages should be recreated once we restart the connector