### PR TITLE
[dev/customer-support] Add origin importer certificate config

### DIFF
--- a/dev-aws/kafka-shared-msk/customer-support/vulnerability.tf
+++ b/dev-aws/kafka-shared-msk/customer-support/vulnerability.tf
@@ -71,3 +71,10 @@ module "vulnerability_bq_v1_scores" {
   consume_topics   = [kafka_topic.vulnerability_v7.name]
   consume_groups   = ["customer-support.vulnerability-scores-benthos-bq-20092023-1"]
 }
+
+# Import batch job for Origin customers
+module "vulnerability_origin_importer" {
+  source           = "../../../modules/tls-app"
+  cert_common_name = "crm/vulnerability-origin-importer"
+  produce_topics   = [kafka_topic.vulnerability_v7.name]
+}


### PR DESCRIPTION
Adds Kafka client certificate config for access to product to the Vulnerability topic. This is for the Origin customer importer. 