### PR TITLE
add invoice-fulfilment topic to mail sender dlq produce topics

### DIFF
--- a/prod-aws/kafka-shared-msk/customer-billing/modules.tf
+++ b/prod-aws/kafka-shared-msk/customer-billing/modules.tf
@@ -173,6 +173,7 @@ module "mail_sender_dlq_job" {
   consume_groups = [
     "bex.mail-sender-dlq-job"
   ]
+  produce_topics = [kafka_topic.invoice_fulfillment.name]
 }
 
 module "invoice_api" {


### PR DESCRIPTION
allows mail-sender dlq job to feed messages back into the topic that mail sender consumes from, to allow this dlq job to work - https://github.com/utilitywarehouse/kubernetes-manifests/pull/108711