### PR TITLE
[Dev] Add Webhook Processor as a Producer

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/energy-platform.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/energy-platform.tf
@@ -113,8 +113,8 @@ resource "kafka_topic" "gentrack_billing_events" {
 }
 
 module "gentrack_adapter_webhook_processor" {
-  source           = "../../../modules/tls-app"
-  produce_topics   = [
+  source = "../../../modules/tls-app"
+  produce_topics = [
     kafka_topic.gentrack_meter_reads.name,
     kafka_topic.gentrack_billing_events.name
   ]


### PR DESCRIPTION
This pull request adds a new module configuration to the `energy-platform.tf` file, introducing the `gentrack_adapter_webhook_processor` module to produce on specific Kafka topics.