### PR TITLE
Use Only One Indexer

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -35,8 +35,8 @@ resource "kafka_topic" "gentrack_billing_events" {
 }
 
 module "gentrack_topic_indexer" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [
+  source = "../../../modules/tls-app"
+  consume_topics = [
     kafka_topic.gentrack_meter_read_events.name,
     kafka_topic.gentrack_billing_events.name
   ]


### PR DESCRIPTION
https://utilitywarehouse.slack.com/archives/C08MLDDQY65/p1749717197073449

We can use one indexer for multiple topics which will simplify deployments a lot