### PR TITLE
Allow meter-reads-api-projector to Consume Gentrack Reads Topic

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/meter-reads.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/meter-reads.tf
@@ -49,8 +49,11 @@ module "meter_reads_api_queue" {
 }
 
 module "meter_reads_api_projector" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.meter_reads.name]
+  source = "../../../modules/tls-app"
+  consume_topics = [
+    kafka_topic.meter_reads.name,
+    kafka_topic.gentrack_meter_read_events.name
+  ]
   consume_groups   = ["energy-platform.meter-reads-api-projector"]
   cert_common_name = "energy-platform/meter-reads-api-projector"
 }


### PR DESCRIPTION
This pull request updates the `meter_reads_api_projector` module configuration in the `meter-reads.tf` file to include an additional Kafka topic for consumption. 

Key change:

* [`dev-aws/kafka-shared-msk/energy-platform/meter-reads.tf`](diffhunk://#diff-fa7026e982edfb4f7416242db2d34a54fbabbe3c7339825ccb7f9728ea47871bL53-R56): Added `kafka_topic.gentrack_meter_read_events.name` to the `consume_topics` list, allowing the `meter_reads_api_projector` module to consume events from the new Kafka topic alongside the existing `meter_reads` topic.