### PR TITLE
new gentrack related kafka topic created

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -35,14 +35,14 @@ resource "kafka_topic" "gentrack_billing_events" {
 }
 
 resource "kafka_topic" "gentrack_migration_events" {
-  name = "energy-platform.gentrack.migration.events"
+  name               = "energy-platform.gentrack.migration.events"
   replication_factor = 3
-  partitions = 15
+  partitions         = 15
 
   config = {
     # Use tiered storage
     "remote.storage.enable" = "true"
-    # keep data for approx 6 months
+    # keep data for 6 months
     "retention.ms" = "15552000000"
     # keep data in primary storage for 2 days
     "local.retention.ms" = "172800000"
@@ -75,8 +75,8 @@ module "gentrack_adapter_webhook_processor" {
 }
 
 module "gentrack_migration" {
-  source = "../../../modules/tls-app"
-  consume_topics = [kafka_topic.gentrack_migration_events.name]
+  source           = "../../../modules/tls-app"
+  consume_topics   = [kafka_topic.gentrack_migration_events.name]
   cert_common_name = "energy-platform/gentrack-migration"
 }
 

--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -42,7 +42,7 @@ resource "kafka_topic" "gentrack_migration_events" {
   config = {
     # Use tiered storage
     "remote.storage.enable" = "true"
-    # keep data for approx 6 month
+    # keep data for approx 6 months
     "retention.ms" = "15552000000"
     # keep data in primary storage for 2 days
     "local.retention.ms" = "172800000"

--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -34,11 +34,31 @@ resource "kafka_topic" "gentrack_billing_events" {
   }
 }
 
+resource "kafka_topic" "gentrack_migration_events" {
+  name = "energy-platform.gentrack.migration.events"
+  replication_factor = 3
+  partitions = 15
+
+  config = {
+    # Use tiered storage
+    "remote.storage.enable" = "true"
+    # keep data for approx 6 month
+    "retention.ms" = "15552000000"
+    # keep data in primary storage for 2 days
+    "local.retention.ms" = "172800000"
+    # allow for a batch of records maximum 1MiB
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
 module "gentrack_topic_indexer" {
   source = "../../../modules/tls-app"
   consume_topics = [
     kafka_topic.gentrack_meter_read_events.name,
-    kafka_topic.gentrack_billing_events.name
+    kafka_topic.gentrack_billing_events.name,
+    kafka_topic.gentrack_migration_events.name
   ]
   consume_groups   = ["energy-platform.gentrack-topic-indexer"]
   cert_common_name = "energy-platform/gentrack-topic-indexer"
@@ -48,9 +68,16 @@ module "gentrack_adapter_webhook_processor" {
   source = "../../../modules/tls-app"
   produce_topics = [
     kafka_topic.gentrack_meter_read_events.name,
-    kafka_topic.gentrack_billing_events.name
+    kafka_topic.gentrack_billing_events.name,
+    kafka_topic.gentrack_migration_events.name
   ]
   cert_common_name = "energy-platform/gentrack-adapter-webhook-processor"
+}
+
+module "gentrack_migration" {
+  source = "../../../modules/tls-app"
+  consume_topics = [kafka_topic.gentrack_migration_events.name]
+  cert_common_name = "energy-platform/gentrack-migration"
 }
 
 module "billing_adapter" {


### PR DESCRIPTION
This PR adds new kafka topic - energy-platform.gentrack.migration.events topic. It will be used to pass migration specific events to the gentrack-migration service