### PR TITLE
[EIN-1844] Rename

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -53,8 +53,8 @@ resource "kafka_topic" "gentrack_migration_events" {
   }
 }
 
-resource "kafka_topic" "gentrack_registration_events" {
-  name               = "energy-platform.gentrack.registration.events"
+resource "kafka_topic" "gentrack_market_interactions_events" {
+  name               = "energy-platform.gentrack.market_interactions.events"
   replication_factor = 3
   partitions         = 15
 
@@ -78,7 +78,7 @@ module "gentrack_topic_indexer" {
     kafka_topic.gentrack_meter_read_events.name,
     kafka_topic.gentrack_billing_events.name,
     kafka_topic.gentrack_migration_events.name,
-    kafka_topic.gentrack_registration_events.name
+    kafka_topic.gentrack_market_interactions_events.name
   ]
   consume_groups   = ["energy-platform.gentrack-topic-indexer"]
   cert_common_name = "energy-platform/gentrack-topic-indexer"
@@ -90,7 +90,7 @@ module "gentrack_adapter_webhook_processor" {
     kafka_topic.gentrack_meter_read_events.name,
     kafka_topic.gentrack_billing_events.name,
     kafka_topic.gentrack_migration_events.name,
-    kafka_topic.gentrack_registration_events.name
+    kafka_topic.gentrack_market_interactions_events.name
   ]
   cert_common_name = "energy-platform/gentrack-adapter-webhook-processor"
 }
@@ -99,7 +99,7 @@ module "gentrack_migration" {
   source = "../../../modules/tls-app"
   consume_topics = [
     kafka_topic.gentrack_migration_events.name,
-    kafka_topic.gentrack_registration_events.name
+    kafka_topic.gentrack_market_interactions_events.name
   ]
   cert_common_name = "energy-platform/gentrack-migration"
 }

--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -53,12 +53,32 @@ resource "kafka_topic" "gentrack_migration_events" {
   }
 }
 
+resource "kafka_topic" "gentrack_registration_events" {
+  name               = "energy-platform.gentrack.registration.events"
+  replication_factor = 3
+  partitions         = 15
+
+  config = {
+    # Use tiered storage
+    "remote.storage.enable" = "true"
+    # keep data for 6 months
+    "retention.ms" = "15552000000"
+    # keep data in primary storage for 2 days
+    "local.retention.ms" = "172800000"
+    # allow for a batch of records maximum 1MiB
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
 module "gentrack_topic_indexer" {
   source = "../../../modules/tls-app"
   consume_topics = [
     kafka_topic.gentrack_meter_read_events.name,
     kafka_topic.gentrack_billing_events.name,
-    kafka_topic.gentrack_migration_events.name
+    kafka_topic.gentrack_migration_events.name,
+    kafka_topic.gentrack_registration_events.name
   ]
   consume_groups   = ["energy-platform.gentrack-topic-indexer"]
   cert_common_name = "energy-platform/gentrack-topic-indexer"
@@ -69,7 +89,8 @@ module "gentrack_adapter_webhook_processor" {
   produce_topics = [
     kafka_topic.gentrack_meter_read_events.name,
     kafka_topic.gentrack_billing_events.name,
-    kafka_topic.gentrack_migration_events.name
+    kafka_topic.gentrack_migration_events.name,
+    kafka_topic.gentrack_registration_events.name
   ]
   cert_common_name = "energy-platform/gentrack-adapter-webhook-processor"
 }
@@ -78,6 +99,12 @@ module "gentrack_migration" {
   source           = "../../../modules/tls-app"
   consume_topics   = [kafka_topic.gentrack_migration_events.name]
   cert_common_name = "energy-platform/gentrack-migration"
+}
+
+module "gentrack_registration" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = [kafka_topic.gentrack_registration_events.name]
+  cert_common_name = "energy-platform/gentrack-registration"
 }
 
 module "billing_adapter" {

--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -96,16 +96,14 @@ module "gentrack_adapter_webhook_processor" {
 }
 
 module "gentrack_migration" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.gentrack_migration_events.name]
+  source = "../../../modules/tls-app"
+  consume_topics = [
+    kafka_topic.gentrack_migration_events.name,
+    kafka_topic.gentrack_registration_events.name
+  ]
   cert_common_name = "energy-platform/gentrack-migration"
 }
 
-module "gentrack_registration" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.gentrack_registration_events.name]
-  cert_common_name = "energy-platform/gentrack-registration"
-}
 
 module "billing_adapter" {
   source           = "../../../modules/tls-app"


### PR DESCRIPTION
Topic should be renamed since it handle any cosloss and cosgain events, gentrack uses the name market interactions for these. 
