### PR TITLE
feat: allow benthos sqs queue processor to produce

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -135,6 +135,12 @@ module "billing_adapter" {
   cert_common_name = "energy-billing/billing-adapter"
 }
 
+module "billing_sqs_processor" {
+  source           = "../../../modules/tls-app"
+  produce_topics   = [kafka_topic.gentrack_billing_events.name]
+  cert_common_name = "energy-billing/billing-sqs-processor"
+}
+
 module "gentrack_billing_test_producer" {
   source           = "../../../modules/tls-app"
   produce_topics   = [kafka_topic.gentrack_billing_events.name]


### PR DESCRIPTION
- allow benthos energy billing sqs-processor to produce to billing events topic.

- we receive billing blobs in an S3 bucket then we get an SQS queue notification which we use benthos to bridge the SQS messages > kafka.