### PR TITLE
chore: add consumer for test-account-orchestrator

### DIFF
--- a/dev-aws/kafka-shared-msk/account-identity/kafka-connect.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/kafka-connect.tf
@@ -8,6 +8,6 @@ module "kafka_connect_read_legacy_account_events" {
 module "qe_tao_read_legacy_account_events" {
   source           = "../../../modules/tls-app"
   consume_topics   = ["account-identity.legacy.account.events"]
-  consume_groups   = ["dev-enablement.qe-tao-service-consumer-group"]
+  consume_groups   = ["dev-enablement.qe-tao-consumer-group"]
   cert_common_name = "dev-enablement/qe-tao-msk-client"
 }


### PR DESCRIPTION
## Description
We have a need to be able to listen for `AccountHoldersChangedEvent`s before firing requests to update email addresses on test accounts

ref: https://github.com/utilitywarehouse/kubernetes-manifests/pull/116278