### PR TITLE
Add meter-reads-api-projector to Gentrack Topics

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/meter-reads.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/meter-reads.tf
@@ -52,7 +52,8 @@ module "meter_reads_api_projector" {
   source = "../../../modules/tls-app"
   consume_topics = [
     kafka_topic.meter_reads.name,
-    kafka_topic.gentrack_meter_read_events.name
+    kafka_topic.gentrack_meter_read_events.name,
+    kafka_topic.gentrack_market_interactions_events.name
   ]
   consume_groups   = ["energy-platform.meter-reads-api-projector"]
   cert_common_name = "energy-platform/meter-reads-api-projector"

--- a/prod-aws/kafka-shared-msk/energy-platform/meter-reads.tf
+++ b/prod-aws/kafka-shared-msk/energy-platform/meter-reads.tf
@@ -49,7 +49,7 @@ module "meter_reads_api_queue" {
 }
 
 module "meter_reads_api_projector" {
-  source           = "../../../modules/tls-app"
+  source = "../../../modules/tls-app"
   consume_topics = [
     kafka_topic.meter_reads.name,
     kafka_topic.gentrack_meter_read_events.name,

--- a/prod-aws/kafka-shared-msk/energy-platform/meter-reads.tf
+++ b/prod-aws/kafka-shared-msk/energy-platform/meter-reads.tf
@@ -50,7 +50,11 @@ module "meter_reads_api_queue" {
 
 module "meter_reads_api_projector" {
   source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.meter_reads.name]
+  consume_topics = [
+    kafka_topic.meter_reads.name,
+    kafka_topic.gentrack_meter_read_events.name,
+    kafka_topic.gentrack_market_interactions_events.name
+  ]
   consume_groups   = ["energy-platform.meter-reads-api-projector"]
   cert_common_name = "energy-platform/meter-reads-api-projector"
 }


### PR DESCRIPTION
- Allow the projector to access market interactions
- Keep prod aligned (It's currently disabled in prod)