### PR TITLE
Introduced infinite topic retention validation with suppressing the rule

### DIFF
--- a/.tflint-msk.hcl
+++ b/.tflint-msk.hcl
@@ -8,7 +8,7 @@ plugin "terraform" {
 plugin "uw-kafka-config" {
   enabled = true
 
-  version = "1.10.0"
+  version = "1.11.0"
   source  = "github.com/utilitywarehouse/tflint-ruleset-kafka-config"
 }
 

--- a/dev-aws/kafka-shared-msk/account-identity/account.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/account.tf
@@ -3,6 +3,7 @@ resource "kafka_topic" "account_identity_account_events_v2" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"
@@ -19,6 +20,7 @@ resource "kafka_topic" "account_identity_account_atomic_v1" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"
@@ -77,6 +79,7 @@ resource "kafka_topic" "account_identity_public_account_events" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
@@ -137,6 +140,7 @@ resource "kafka_topic" "account_identity_account_history_v1" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"

--- a/dev-aws/kafka-shared-msk/account-identity/exceptions.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/exceptions.tf
@@ -7,6 +7,7 @@ resource "kafka_topic" "account_identity_account_exceptions_v1" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "account-identity.account.exceptions.v1"
@@ -35,6 +36,7 @@ resource "kafka_topic" "account_identity_supply_address_exception_check_events" 
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms"     = "-1"
     "compression.type" = "zstd"
 
@@ -52,6 +54,7 @@ resource "kafka_topic" "account_identity_supply_address_debt_exception_check_eve
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms"     = "-1"
     "compression.type" = "zstd"
   }
@@ -68,6 +71,7 @@ resource "kafka_topic" "account_identity_correspondence_address_exception_check_
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms"     = "-1"
     "compression.type" = "zstd"
   }
@@ -85,6 +89,7 @@ resource "kafka_topic" "account_identity_land_registry_check_events" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "account-identity.land-registry.check.events"
@@ -100,6 +105,7 @@ resource "kafka_topic" "account_identity_correspondence_address_debt_exception_c
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms"     = "-1"
     "compression.type" = "zstd"
   }

--- a/dev-aws/kafka-shared-msk/account-identity/legacy_account.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/legacy_account.tf
@@ -29,6 +29,7 @@ resource "kafka_topic" "account_identity_legacy_account_events" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"
@@ -81,6 +82,7 @@ resource "kafka_topic" "account_identity_legacy_account_created_in_bill_events" 
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"
@@ -97,6 +99,7 @@ resource "kafka_topic" "account_identity_legacy_account_events_private" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"

--- a/dev-aws/kafka-shared-msk/account-identity/okta.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/okta.tf
@@ -3,6 +3,7 @@ resource "kafka_topic" "account_identity_staff_okta_v6" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"

--- a/dev-aws/kafka-shared-msk/billing/billing.tf
+++ b/dev-aws/kafka-shared-msk/billing/billing.tf
@@ -47,6 +47,7 @@ resource "kafka_topic" "unified_bill_ready_events" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # delete old data
     "cleanup.policy" = "delete"

--- a/dev-aws/kafka-shared-msk/cbc/cbc.tf
+++ b/dev-aws/kafka-shared-msk/cbc/cbc.tf
@@ -7,12 +7,13 @@ resource "kafka_topic" "FraudEvents" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -41,12 +42,13 @@ resource "kafka_topic" "rating_events_v3" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -58,12 +60,13 @@ resource "kafka_topic" "challenge_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -75,12 +78,13 @@ resource "kafka_topic" "charges_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -92,12 +96,13 @@ resource "kafka_topic" "lifecycle_events_v2" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -109,12 +114,13 @@ resource "kafka_topic" "topup_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -126,12 +132,13 @@ resource "kafka_topic" "transaction_events_v3" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -143,12 +150,13 @@ resource "kafka_topic" "openbanking_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -160,12 +168,13 @@ resource "kafka_topic" "order_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -177,12 +186,13 @@ resource "kafka_topic" "paymentology_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -194,12 +204,13 @@ resource "kafka_topic" "sodexo_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -211,12 +222,13 @@ resource "kafka_topic" "verification_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -228,12 +240,13 @@ resource "kafka_topic" "customer_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -245,12 +258,13 @@ resource "kafka_topic" "migration_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -262,12 +276,13 @@ resource "kafka_topic" "network_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -279,12 +294,13 @@ resource "kafka_topic" "mdes_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -296,12 +312,13 @@ resource "kafka_topic" "service_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -313,12 +330,13 @@ resource "kafka_topic" "crm_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -330,12 +348,13 @@ resource "kafka_topic" "legacy_account_events_v2" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -347,12 +366,13 @@ resource "kafka_topic" "eqdb_loader_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "2097152" # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "2097152" # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 

--- a/dev-aws/kafka-shared-msk/customer-proposition/bundle-tier.tf
+++ b/dev-aws/kafka-shared-msk/customer-proposition/bundle-tier.tf
@@ -22,7 +22,8 @@ resource "kafka_topic" "bundletier_events_v1" {
   config = {
     "remote.storage.enable" = "true"
     "retention.bytes"       = "-1" # keep on each partition unlimited data
-    "retention.ms"          = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
     # allow for a batch of records maximum 1MiB

--- a/dev-aws/kafka-shared-msk/customer-proposition/customer-proposition.tf
+++ b/dev-aws/kafka-shared-msk/customer-proposition/customer-proposition.tf
@@ -8,7 +8,8 @@ resource "kafka_topic" "uswitch_data_v1" {
   config = {
     "remote.storage.enable" = "true"
     "retention.bytes"       = "-1" # keep on each partition unlimited data
-    "retention.ms"          = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
     # allow for a batch of records maximum 1MiB
@@ -28,7 +29,8 @@ resource "kafka_topic" "uswitch_events_v2" {
   config = {
     "remote.storage.enable" = "true"
     "retention.bytes"       = "-1" # keep on each partition unlimited data
-    "retention.ms"          = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
     # allow for a batch of records maximum 1MiB
@@ -49,7 +51,8 @@ resource "kafka_topic" "service_status_v3" {
   config = {
     "remote.storage.enable" = "true"
     "retention.bytes"       = "-1" # keep on each partition unlimited data
-    "retention.ms"          = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
     # allow for a batch of records maximum 1MiB
@@ -69,7 +72,8 @@ resource "kafka_topic" "service_status_v4" {
   config = {
     "remote.storage.enable" = "true"
     "retention.bytes"       = "-1" # keep on each partition unlimited data
-    "retention.ms"          = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
     # allow for a batch of records maximum 1MiB
@@ -89,7 +93,8 @@ resource "kafka_topic" "service_status_deadletter_v4" {
   config = {
     "remote.storage.enable" = "true"
     "retention.bytes"       = "-1" # keep on each partition unlimited data
-    "retention.ms"          = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
     # allow for a batch of records maximum 1MiB

--- a/dev-aws/kafka-shared-msk/customer-support/coffee.tf
+++ b/dev-aws/kafka-shared-msk/customer-support/coffee.tf
@@ -8,6 +8,7 @@ resource "kafka_topic" "coffee_account_history_v1" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.coffee_account_history_v1"
@@ -25,6 +26,7 @@ resource "kafka_topic" "coffee_services" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.coffee_services"

--- a/dev-aws/kafka-shared-msk/customer-support/payments.tf
+++ b/dev-aws/kafka-shared-msk/customer-support/payments.tf
@@ -8,6 +8,7 @@ resource "kafka_topic" "payments_audit_log_v1" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.payments_audit_log_v1"

--- a/dev-aws/kafka-shared-msk/customer-support/reminders.tf
+++ b/dev-aws/kafka-shared-msk/customer-support/reminders.tf
@@ -8,6 +8,7 @@ resource "kafka_topic" "reminders_v1" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.reminders_v1"

--- a/dev-aws/kafka-shared-msk/customer-support/vulnerability.tf
+++ b/dev-aws/kafka-shared-msk/customer-support/vulnerability.tf
@@ -8,6 +8,7 @@ resource "kafka_topic" "vulnerability_v7" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.vulnerability_v7"

--- a/dev-aws/kafka-shared-msk/customer-support/william.tf
+++ b/dev-aws/kafka-shared-msk/customer-support/william.tf
@@ -8,6 +8,7 @@ resource "kafka_topic" "notes_v2" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.notes_v2"
@@ -25,6 +26,7 @@ resource "kafka_topic" "ticketing_v2" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.ticketing_v2"

--- a/dev-aws/kafka-shared-msk/data-infra/api.tf
+++ b/dev-aws/kafka-shared-msk/data-infra/api.tf
@@ -5,6 +5,7 @@ resource "kafka_topic" "events" {
   config = {
     "remote.storage.enable" = "true"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"

--- a/dev-aws/kafka-shared-msk/data-infra/connectors.tf
+++ b/dev-aws/kafka-shared-msk/data-infra/connectors.tf
@@ -5,6 +5,7 @@ resource "kafka_topic" "events_end" {
   config = {
     "remote.storage.enable" = "true"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"

--- a/dev-aws/kafka-shared-msk/insurance/insurance.tf
+++ b/dev-aws/kafka-shared-msk/insurance/insurance.tf
@@ -7,12 +7,13 @@ resource "kafka_topic" "public_policies_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 

--- a/prod-aws/kafka-shared-msk/account-identity/account.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/account.tf
@@ -4,6 +4,7 @@ resource "kafka_topic" "account_identity_account_events_v2" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"
@@ -20,6 +21,7 @@ resource "kafka_topic" "account_identity_account_atomic_v1" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"
@@ -48,6 +50,7 @@ resource "kafka_topic" "account_identity_public_account_events" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
@@ -68,7 +71,8 @@ resource "kafka_topic" "account_identity_account_management_events" {
     "local.retention.ms" = "86400000"
     # enable remote storage
     "remote.storage.enable" = "true"
-    "retention.ms"          = -1 # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = -1 # keep data forever
   }
   name               = "account-identity.account-management-events-green"
   partitions         = 1
@@ -96,6 +100,7 @@ resource "kafka_topic" "account_identity_account_events_v3" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
@@ -113,6 +118,7 @@ resource "kafka_topic" "account_identity_address_lookup_analytics_v1" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
@@ -159,6 +165,7 @@ resource "kafka_topic" "account_identity_account_history_v1" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"

--- a/prod-aws/kafka-shared-msk/account-identity/exceptions.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/exceptions.tf
@@ -7,6 +7,7 @@ resource "kafka_topic" "account_identity_account_exceptions_v1" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "account-identity.account.exceptions.v1"
@@ -69,6 +70,7 @@ resource "kafka_topic" "account_identity_land_registry_check_events" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "account-identity.land-registry.check.events"
@@ -97,6 +99,7 @@ resource "kafka_topic" "account_identity_land_registry_check_events_test" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"

--- a/prod-aws/kafka-shared-msk/account-identity/legacy_account.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/legacy_account.tf
@@ -30,6 +30,7 @@ resource "kafka_topic" "account_identity_legacy_account_events" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"
@@ -87,6 +88,7 @@ resource "kafka_topic" "account_identity_legacy_account_created_in_bill_events" 
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"
@@ -103,6 +105,7 @@ resource "kafka_topic" "account_identity_legacy_account_events_private" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"
@@ -119,6 +122,7 @@ resource "kafka_topic" "account_identity_legacy_account_eqdb_events" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"

--- a/prod-aws/kafka-shared-msk/account-identity/okta.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/okta.tf
@@ -3,6 +3,7 @@ resource "kafka_topic" "account_identity_staff_okta_v6" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # enable remote storage
     "remote.storage.enable" = "true"

--- a/prod-aws/kafka-shared-msk/billing/billing.tf
+++ b/prod-aws/kafka-shared-msk/billing/billing.tf
@@ -47,6 +47,7 @@ resource "kafka_topic" "unified_bill_ready_events" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # delete old data
     "cleanup.policy" = "delete"

--- a/prod-aws/kafka-shared-msk/cbc/cbc.tf
+++ b/prod-aws/kafka-shared-msk/cbc/cbc.tf
@@ -6,12 +6,13 @@ resource "kafka_topic" "fraud_events" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -40,12 +41,13 @@ resource "kafka_topic" "rating_events_v3" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -57,12 +59,13 @@ resource "kafka_topic" "challenge_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -74,12 +77,13 @@ resource "kafka_topic" "charges_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -91,12 +95,13 @@ resource "kafka_topic" "lifecycle_events_v2" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -108,12 +113,13 @@ resource "kafka_topic" "topup_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -125,12 +131,13 @@ resource "kafka_topic" "transaction_events_v3" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -142,12 +149,13 @@ resource "kafka_topic" "openbanking_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -159,12 +167,13 @@ resource "kafka_topic" "order_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -176,12 +185,13 @@ resource "kafka_topic" "paymentology_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -193,12 +203,13 @@ resource "kafka_topic" "sodexo_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -210,12 +221,13 @@ resource "kafka_topic" "verification_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -227,12 +239,13 @@ resource "kafka_topic" "customer_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -244,12 +257,13 @@ resource "kafka_topic" "migration_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -261,12 +275,13 @@ resource "kafka_topic" "network_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -278,12 +293,13 @@ resource "kafka_topic" "mdes_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -295,12 +311,13 @@ resource "kafka_topic" "service_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -312,12 +329,13 @@ resource "kafka_topic" "crm_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -329,12 +347,13 @@ resource "kafka_topic" "legacy_account_events_v2" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -346,12 +365,13 @@ resource "kafka_topic" "eqdb_loader_events_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"       # keep on each partition unlimited data
-    "retention.ms"          = "-1"       # keep data forever
-    "local.retention.ms"    = "18000000" # keep data in primary storage for 5 hours
-    "max.message.bytes"     = "2097152"  # allow for a batch of records maximum 2MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"       # keep data forever
+    "local.retention.ms" = "18000000" # keep data in primary storage for 5 hours
+    "max.message.bytes"  = "2097152"  # allow for a batch of records maximum 2MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 

--- a/prod-aws/kafka-shared-msk/customer-billing/topics.tf
+++ b/prod-aws/kafka-shared-msk/customer-billing/topics.tf
@@ -176,7 +176,8 @@ resource "kafka_topic" "public_fulfilment_events" {
     "remote.storage.enable" = "true"
     # keep on each partition unlimited data
     "retention.bytes" = "-1"
-    "retention.ms"    = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # allow for a batch of records maximum 1MiB

--- a/prod-aws/kafka-shared-msk/customer-proposition/bundle-tier.tf
+++ b/prod-aws/kafka-shared-msk/customer-proposition/bundle-tier.tf
@@ -22,7 +22,8 @@ resource "kafka_topic" "bundletier_events_v1" {
   config = {
     "remote.storage.enable" = "true"
     "retention.bytes"       = "-1" # keep on each partition unlimited data
-    "retention.ms"          = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
     # allow for a batch of records maximum 1MiB

--- a/prod-aws/kafka-shared-msk/customer-proposition/customer-proposition.tf
+++ b/prod-aws/kafka-shared-msk/customer-proposition/customer-proposition.tf
@@ -8,7 +8,8 @@ resource "kafka_topic" "uswitch_data_v1" {
   config = {
     "remote.storage.enable" = "true"
     "retention.bytes"       = "-1" # keep on each partition unlimited data
-    "retention.ms"          = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
     # allow for a batch of records maximum 1MiB
@@ -28,7 +29,8 @@ resource "kafka_topic" "uswitch_events_v2" {
   config = {
     "remote.storage.enable" = "true"
     "retention.bytes"       = "-1" # keep on each partition unlimited data
-    "retention.ms"          = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
     # allow for a batch of records maximum 1MiB
@@ -48,7 +50,8 @@ resource "kafka_topic" "service_status_v4" {
   config = {
     "remote.storage.enable" = "true"
     "retention.bytes"       = "-1" # keep on each partition unlimited data
-    "retention.ms"          = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
     # allow for a batch of records maximum 1MiB
@@ -68,7 +71,8 @@ resource "kafka_topic" "service_status_deadletter_v4" {
   config = {
     "remote.storage.enable" = "true"
     "retention.bytes"       = "-1" # keep on each partition unlimited data
-    "retention.ms"          = "-1" # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms" = "-1" # keep data forever
     # keep data in primary storage for 1 hour
     "local.retention.ms" = "3600000"
     # allow for a batch of records maximum 1MiB

--- a/prod-aws/kafka-shared-msk/customer-support/coffee.tf
+++ b/prod-aws/kafka-shared-msk/customer-support/coffee.tf
@@ -8,6 +8,7 @@ resource "kafka_topic" "coffee_account_history_v1" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.coffee_account_history_v1"
@@ -25,6 +26,7 @@ resource "kafka_topic" "coffee_services" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.coffee_services"

--- a/prod-aws/kafka-shared-msk/customer-support/payments.tf
+++ b/prod-aws/kafka-shared-msk/customer-support/payments.tf
@@ -8,6 +8,7 @@ resource "kafka_topic" "payments_audit_log_v1" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.payments_audit_log_v1"

--- a/prod-aws/kafka-shared-msk/customer-support/reminders.tf
+++ b/prod-aws/kafka-shared-msk/customer-support/reminders.tf
@@ -8,6 +8,7 @@ resource "kafka_topic" "reminders_v1" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.reminders_v1"

--- a/prod-aws/kafka-shared-msk/customer-support/vulnerability.tf
+++ b/prod-aws/kafka-shared-msk/customer-support/vulnerability.tf
@@ -8,6 +8,7 @@ resource "kafka_topic" "vulnerability_v6" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.vulnerability_v6"

--- a/prod-aws/kafka-shared-msk/customer-support/william.tf
+++ b/prod-aws/kafka-shared-msk/customer-support/william.tf
@@ -8,6 +8,7 @@ resource "kafka_topic" "notes_v2" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.notes_v2"
@@ -25,6 +26,7 @@ resource "kafka_topic" "ticketing_v2" {
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
   }
   name               = "customer-support.ticketing_v2"

--- a/prod-aws/kafka-shared-msk/data-infra/api.tf
+++ b/prod-aws/kafka-shared-msk/data-infra/api.tf
@@ -5,6 +5,7 @@ resource "kafka_topic" "events" {
   config = {
     "remote.storage.enable" = "true"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"

--- a/prod-aws/kafka-shared-msk/data-infra/connectors.tf
+++ b/prod-aws/kafka-shared-msk/data-infra/connectors.tf
@@ -5,6 +5,7 @@ resource "kafka_topic" "events_end" {
   config = {
     "remote.storage.enable" = "true"
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"

--- a/prod-aws/kafka-shared-msk/insurance/backup.tf
+++ b/prod-aws/kafka-shared-msk/insurance/backup.tf
@@ -27,12 +27,13 @@ resource "kafka_topic" "private_accounts_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -44,12 +45,13 @@ resource "kafka_topic" "private_claims_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -61,12 +63,13 @@ resource "kafka_topic" "private_comms_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -78,12 +81,13 @@ resource "kafka_topic" "private_coverage_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -95,12 +99,13 @@ resource "kafka_topic" "private_documents_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -112,12 +117,13 @@ resource "kafka_topic" "private_durell_edi_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -129,12 +135,13 @@ resource "kafka_topic" "private_eligibility_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -146,12 +153,13 @@ resource "kafka_topic" "private_renewal_dates_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -163,12 +171,13 @@ resource "kafka_topic" "private_policies_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -180,12 +189,13 @@ resource "kafka_topic" "private_policy_prices_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 
@@ -197,11 +207,12 @@ resource "kafka_topic" "private_quotes_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }

--- a/prod-aws/kafka-shared-msk/insurance/insurance.tf
+++ b/prod-aws/kafka-shared-msk/insurance/insurance.tf
@@ -7,12 +7,13 @@ resource "kafka_topic" "public_policies_v1" {
 
   config = {
     "remote.storage.enable" = "true"
-    "retention.bytes"       = "-1"      # keep on each partition unlimited data
-    "retention.ms"          = "-1"      # keep data forever
-    "local.retention.ms"    = "3600000" # keep data in primary storage for 1 hour
-    "max.message.bytes"     = "1048576" # allow for a batch of records maximum 1MiB
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    "retention.bytes"       = "-1" # keep on each partition unlimited data
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
+    "retention.ms"       = "-1"      # keep data forever
+    "local.retention.ms" = "3600000" # keep data in primary storage for 1 hour
+    "max.message.bytes"  = "1048576" # allow for a batch of records maximum 1MiB
+    "compression.type"   = "zstd"
+    "cleanup.policy"     = "delete"
   }
 }
 

--- a/prod-aws/kafka-shared-msk/ledgers/ledger.tf
+++ b/prod-aws/kafka-shared-msk/ledgers/ledger.tf
@@ -12,6 +12,7 @@ resource "kafka_topic" "account_balance_events" {
     "local.retention.ms" = "172800000"
     # TODO revisit
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # delete old data
     "cleanup.policy" = "delete"
@@ -31,6 +32,7 @@ resource "kafka_topic" "transaction_events" {
     "local.retention.ms" = "172800000"
     # TODO revisit
     # keep data forever
+    # tflint-ignore: msk_topic_no_infinite_retention, # infinite retention because ...
     "retention.ms" = "-1"
     # delete old data
     "cleanup.policy" = "delete"


### PR DESCRIPTION
Infinite topic retention is **NOT** recommended, even in MSK.

Please review these topics, check if infinite retention is really necessary and **input the reason why** in the comment.

Long term, please plan on **migrating away** from them.
Some alternatives are documented in the [rule's documentation](https://github.com/utilitywarehouse/tflint-ruleset-kafka-config/blob/main/rules/msk_topic_no_infinite_retention.md).
