### PR TITLE
Rename prepayment msk and add permission for gentrack meterpoints topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,8 +14,8 @@ prod-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
 /**/customer-proposition/                         @utilitywarehouse/org-multi-service-innovation
 /**/customer-support/                             @utilitywarehouse/customer-support
 /**/data-infra/                                   @utilitywarehouse/data-infra
-/**/energy-platform/                              @utilitywarehouse/org-energy
-/**/energy-billing/                               @utilitywarehouse/org-energy
+/**/energy-platform/                              @utilitywarehouse/energy
+/**/energy-billing/                               @utilitywarehouse/energy
 /**/finance/                                      @utilitywarehouse/finance-maintainers
 /**/help-and-support/                             @utilitywarehouse/org-help-experience
 /**/iam/                                          @utilitywarehouse/account-identity

--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -170,8 +170,8 @@ module "billing_sqs_processor" {
 }
 
 module "energy_prepayment_projector" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [
+  source = "../../../modules/tls-app"
+  consume_topics = [
     kafka_topic.gentrack_prepayment_events.name,
     kafka_topic.gentrack_meterpoint_events.name
   ]

--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -173,7 +173,7 @@ module "energy_prepayment_projector" {
   source           = "../../../modules/tls-app"
   consume_topics   = [
     kafka_topic.gentrack_prepayment_events.name,
-    kafka_topic.gentrack_meterpoint_events.name,
+    kafka_topic.gentrack_meterpoint_events.name
   ]
   consume_groups   = ["energy-platform.prepayment-projector"]
   cert_common_name = "energy-platform/prepayment-projector"

--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -169,11 +169,14 @@ module "billing_sqs_processor" {
   cert_common_name = "energy-billing/billing-sqs-processor"
 }
 
-module "energy_prepayment_consumer" {
+module "energy_prepayment_projector" {
   source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.gentrack_prepayment_events.name]
-  consume_groups   = ["energy-platform.energy-prepayment-consumer"]
-  cert_common_name = "energy-platform/energy-prepayment-consumer"
+  consume_topics   = [
+    kafka_topic.gentrack_prepayment_events.name,
+    kafka_topic.gentrack_meterpoint_events.name,
+  ]
+  consume_groups   = ["energy-platform.prepayment-projector"]
+  cert_common_name = "energy-platform/prepayment-projector"
 }
 
 module "energy_service_gentrack_registration_consumer" {

--- a/prod-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/prod-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -170,8 +170,8 @@ module "billing_sqs_processor" {
 }
 
 module "energy_prepayment_projector" {
-  source           = "../../../modules/tls-app"
-  consume_topics   = [
+  source = "../../../modules/tls-app"
+  consume_topics = [
     kafka_topic.gentrack_prepayment_events.name,
     kafka_topic.gentrack_meterpoint_events.name
   ]

--- a/prod-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/prod-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -169,9 +169,12 @@ module "billing_sqs_processor" {
   cert_common_name = "energy-billing/billing-sqs-processor"
 }
 
-module "energy_prepayment_consumer" {
+module "energy_prepayment_projector" {
   source           = "../../../modules/tls-app"
-  consume_topics   = [kafka_topic.gentrack_prepayment_events.name]
-  consume_groups   = ["energy-platform.energy-prepayment-consumer"]
-  cert_common_name = "energy-platform/energy-prepayment-consumer"
+  consume_topics   = [
+    kafka_topic.gentrack_prepayment_events.name,
+    kafka_topic.gentrack_meterpoint_events.name,
+  ]
+  consume_groups   = ["energy-platform.prepayment-projector"]
+  cert_common_name = "energy-platform/prepayment-projector"
 }

--- a/prod-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/prod-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -173,7 +173,7 @@ module "energy_prepayment_projector" {
   source           = "../../../modules/tls-app"
   consume_topics   = [
     kafka_topic.gentrack_prepayment_events.name,
-    kafka_topic.gentrack_meterpoint_events.name,
+    kafka_topic.gentrack_meterpoint_events.name
   ]
   consume_groups   = ["energy-platform.prepayment-projector"]
   cert_common_name = "energy-platform/prepayment-projector"


### PR DESCRIPTION
This app is not deployed yet anywhere so the impact/risk of this change is zero.