### PR TITLE
otel: specify s3 backend

### DIFF
--- a/dev-merit/otel/__env.tf
+++ b/dev-merit/otel/__env.tf
@@ -1,7 +1,11 @@
 terraform {
   required_version = ">= 1.5.0"
 
-  backend "s3" {}
+  backend "s3" {
+    bucket = "uw-dev-otel-tf-applier-state"
+    key    = "dev-merit/otel-kafka"
+    region = "eu-west-1"
+  }
 
   required_providers {
     kafka = {

--- a/exp-1-merit/otel/__env.tf
+++ b/exp-1-merit/otel/__env.tf
@@ -1,8 +1,11 @@
 terraform {
   required_version = ">= 1.5.0"
 
-  backend "s3" {}
-
+  backend "s3" {
+    bucket = "uw-dev-otel-tf-applier-state-exp"
+    key    = "exp-1-mert/otel-kafka"
+    region = "eu-west-1"
+  }
   required_providers {
     kafka = {
       source  = "Mongey/kafka"

--- a/prod-merit/otel/__env.tf
+++ b/prod-merit/otel/__env.tf
@@ -1,7 +1,11 @@
 terraform {
   required_version = ">= 1.5.0"
 
-  backend "s3" {}
+  backend "s3" {
+    bucket = "uw-prod-otel-tf-applier-state"
+    key    = "prod-merit/otel-kafka"
+    region = "eu-west-1"
+  }
 
   required_providers {
     kafka = {


### PR DESCRIPTION
Latest terraform 1.15.0, fails validation if the s3 backend is empty.
Doing this so we can revert: #1256