### PR TITLE
udpate gentrack_agreement_events retention policy to 1000

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -139,9 +139,9 @@ resource "kafka_topic" "gentrack_agreement_events" {
     # Use tiered storage
     "remote.storage.enable" = "true"
     # keep data for 6 months
-    "retention.ms" = "15552000000"
+    "retention.ms" = "1000"
     # keep data in primary storage for 2 days
-    "local.retention.ms" = "172800000"
+    "local.retention.ms" = "1000"
     # allow for a batch of records maximum 1MiB
     "max.message.bytes" = "1048576"
     "compression.type"  = "zstd"

--- a/dev-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
+++ b/dev-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
@@ -648,7 +648,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "msk_topics_retention" {
   rule {
     id     = "energy-platform.gentrack.agreement.events"
     status = "Enabled"
-    expiration { days = 181 }
+    expiration { days = 1 }
     filter { prefix = "kafka-backup/energy-platform.gentrack.agreement.events/" }
   }
 


### PR DESCRIPTION
This is to empty the messages out of the Agreement topic. This PR will be reverted once the messages have been cleared.

This PR only needs to be applied to DEV
https://kafka-ui.dev.uw.systems/ui/clusters/shared-msk/all-topics/energy-platform.gentrack.agreement.events/messages?keySerde=String&valueSerde=String&limit=100

Not PROD - because no events have yet reached the topic in PROD:
https://kafka-ui.prod.uw.systems/ui/clusters/shared-msk/all-topics/energy-platform.gentrack.agreement.events/messages?keySerde=String&valueSerde=String&limit=100

We should only merge this PR once the following two PRs have been merged:
https://github.com/utilitywarehouse/energy-contracts/pull/1536
https://github.com/utilitywarehouse/energy-gentrack-adapter/pull/275/changes