### PR TITLE
kakfa data keep dev: improve keeping of the restore resources

### DIFF
--- a/.tflint-msk.hcl
+++ b/.tflint-msk.hcl
@@ -8,7 +8,7 @@ plugin "terraform" {
 plugin "uw-kafka-config" {
   enabled = true
 
-  version = "1.11.0"
+  version = "1.12.0"
   source  = "github.com/utilitywarehouse/tflint-ruleset-kafka-config"
 }
 

--- a/dev-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
+++ b/dev-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
@@ -1017,10 +1017,45 @@ resource "aws_s3_bucket_lifecycle_configuration" "msk_topics_retention" {
   }
 
   rule {
+    id     = "pubsub.plan-topic-restore.large"
+    status = "Enabled"
+    expiration { days = 4 }
+    filter { prefix = "kafka-backup/pubsub.plan-topic-restore.large/" }
+  }
+
+  rule {
+    id     = "pubsub.plan-topic-restore.large"
+    status = "Enabled"
+    expiration { days = 4 }
+    filter { prefix = "kafka-backup/pubsub.plan-topic-restore.large/" }
+  }
+
+  rule {
+    id     = "pubsub.plan-topic-restore.normal"
+    status = "Enabled"
+    expiration { days = 4 }
+    filter { prefix = "kafka-backup/pubsub.plan-topic-restore.normal/" }
+  }
+
+  rule {
+    id     = "pubsub.plan-topic-restore.normal"
+    status = "Enabled"
+    expiration { days = 4 }
+    filter { prefix = "kafka-backup/pubsub.plan-topic-restore.normal/" }
+  }
+
+  rule {
     id     = "pubsub.proximo-example"
     status = "Enabled"
     expiration { days = 3 }
     filter { prefix = "kafka-backup/pubsub.proximo-example/" }
+  }
+
+  rule {
+    id     = "pubsub.restore-test.auth.iam-identitydb-v1"
+    status = "Enabled"
+    expiration { days = 31 }
+    filter { prefix = "kafka-backup/pubsub.restore-test.auth.iam-identitydb-v1/" }
   }
 
   rule {

--- a/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-backup.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-backup.tf
@@ -1,0 +1,23 @@
+resource "kafka_acl" "msk_data_keep_backup_read_topic_all" {
+  resource_name       = "*"
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=pubsub/msk-data-keep-backup"
+  acl_host            = "*"
+  acl_operation       = "Read"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "msk_data_keep_backup_describe_group_all" {
+  resource_name       = "*"
+  resource_type       = "Group"
+  acl_principal       = "User:CN=pubsub/msk-data-keep-backup"
+  acl_host            = "*"
+  acl_operation       = "Describe"
+  acl_permission_type = "Allow"
+}
+
+module "msk_data_keep_backup" {
+  source           = "../../../modules/tls-app"
+  consume_groups   = ["pubsub.msk-data-keep-backup"]
+  cert_common_name = "pubsub/msk-data-keep-backup"
+}

--- a/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-full-cluster.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-full-cluster.tf
@@ -3,64 +3,77 @@
 # It gives permissions for the restore app fully on all topics
 ################################################################
 
-# resource "kafka_topic" "plan_restore_normal" {
-#   name               = "pubsub.plan-topic-restore.normal"
-#   replication_factor = 3
-#   partitions         = 15
-#   config = {
-#     "remote.storage.enable" = "true"
-#     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
-#     # keep data for 3 days
-#     "retention.ms" = "259200000"
-#     # allow for a batch of records maximum 100MiB
-#     "max.message.bytes" = "104857600"
-#     "compression.type"  = "zstd"
-#     "cleanup.policy"    = "delete"
-#   }
-# }
-#
-# resource "kafka_topic" "plan_restore_large" {
-#   name               = "pubsub.plan-topic-restore.large"
-#   replication_factor = 3
-#   partitions         = 15
-#   config = {
-#     "remote.storage.enable" = "true"
-#     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
-#     # keep data for 3 days
-#     "retention.ms" = "259200000"
-#     # allow for a batch of records maximum 100MiB
-#     "max.message.bytes" = "104857600"
-#     "compression.type"  = "zstd"
-#     "cleanup.policy"    = "delete"
-#   }
-# }
-#
-#
-# resource "kafka_acl" "msk_data_keep_restore_write_topic_all" {
-#   resource_name       = "*"
-#   resource_type       = "Topic"
-#   acl_principal       = "User:CN=pubsub/msk-data-keep-restore"
-#   acl_host            = "*"
-#   acl_operation       = "Write"
-#   acl_permission_type = "Allow"
-# }
+#  Use a variable to enable or disable full cluster restore resources.
+#  This allows us to keep the configuration in place for when we need it, without having to rely on git history to bring it back.
+variable "enable_restore_full_cluster" {
+  type = bool
+
+  description = "Set to true to enable full cluster restore resources, false to disable them."
+  default     = false
+}
+resource "kafka_topic" "plan_restore_full_normal" {
+  count              = var.enable_restore_full_cluster ? 1 : 0
+  name               = "pubsub.plan-topic-restore.normal"
+  replication_factor = 3
+  partitions         = 30
+  config = {
+    "remote.storage.enable" = "true"
+    "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
+    # keep data for 3 days
+    "retention.ms" = "259200000"
+    # allow for a batch of records maximum 100MiB
+    "max.message.bytes" = "104857600"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+resource "kafka_topic" "plan_restore_full_large" {
+  count              = var.enable_restore_full_cluster ? 1 : 0
+  name               = "pubsub.plan-topic-restore.large"
+  replication_factor = 3
+  partitions         = 30
+  config = {
+    "remote.storage.enable" = "true"
+    "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
+    # keep data for 3 days
+    "retention.ms" = "259200000"
+    # allow for a batch of records maximum 100MiB
+    "max.message.bytes" = "104857600"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+
+resource "kafka_acl" "msk_data_keep_restore_write_topic_all" {
+  count               = var.enable_restore_full_cluster ? 1 : 0
+  resource_name       = "*"
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=pubsub/msk-data-keep-restore"
+  acl_host            = "*"
+  acl_operation       = "Write"
+  acl_permission_type = "Allow"
+}
 
 # Needed for determining the resume point
-# resource "kafka_acl" "msk_data_keep_restore_read_topic_all" {
-#   resource_name       = "*"
-#   resource_type       = "Topic"
-#   acl_principal       = "User:CN=pubsub/msk-data-keep-restore"
-#   acl_host            = "*"
-#   acl_operation       = "Read"
-#   acl_permission_type = "Allow"
-# }
+resource "kafka_acl" "msk_data_keep_restore_read_topic_all" {
+  count               = var.enable_restore_full_cluster ? 1 : 0
+  resource_name       = "*"
+  resource_type       = "Topic"
+  acl_principal       = "User:CN=pubsub/msk-data-keep-restore"
+  acl_host            = "*"
+  acl_operation       = "Read"
+  acl_permission_type = "Allow"
+}
 
-# resource "kafka_acl" "msk_data_keep_restore_write_groups_all" {
-#   resource_name                = "*"
-#   resource_type                = "Group"
-#   acl_principal                = "User:CN=pubsub/msk-data-keep-restore"
-#   acl_host                     = "*"
-#   # this is non intuitive... we need the Read permission to be able to commit offsets on groups
-#   acl_operation                = "Read"
-#   acl_permission_type          = "Allow"
-# }
+resource "kafka_acl" "msk_data_keep_restore_write_groups_all" {
+  count         = var.enable_restore_full_cluster ? 1 : 0
+  resource_name = "*"
+  resource_type = "Group"
+  acl_principal = "User:CN=pubsub/msk-data-keep-restore"
+  acl_host      = "*"
+  # this is non intuitive... we need the Read permission to be able to commit offsets on groups
+  acl_operation       = "Read"
+  acl_permission_type = "Allow"
+}

--- a/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-full-cluster.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-full-cluster.tf
@@ -1,0 +1,66 @@
+################################################################
+# Enable this configuration when we need to do a FULL cluster restore.
+# It gives permissions for the restore app fully on all topics
+################################################################
+
+# resource "kafka_topic" "plan_restore_normal" {
+#   name               = "pubsub.plan-topic-restore.normal"
+#   replication_factor = 3
+#   partitions         = 15
+#   config = {
+#     "remote.storage.enable" = "true"
+#     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
+#     # keep data for 3 days
+#     "retention.ms" = "259200000"
+#     # allow for a batch of records maximum 100MiB
+#     "max.message.bytes" = "104857600"
+#     "compression.type"  = "zstd"
+#     "cleanup.policy"    = "delete"
+#   }
+# }
+#
+# resource "kafka_topic" "plan_restore_large" {
+#   name               = "pubsub.plan-topic-restore.large"
+#   replication_factor = 3
+#   partitions         = 15
+#   config = {
+#     "remote.storage.enable" = "true"
+#     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
+#     # keep data for 3 days
+#     "retention.ms" = "259200000"
+#     # allow for a batch of records maximum 100MiB
+#     "max.message.bytes" = "104857600"
+#     "compression.type"  = "zstd"
+#     "cleanup.policy"    = "delete"
+#   }
+# }
+#
+#
+# resource "kafka_acl" "msk_data_keep_restore_write_topic_all" {
+#   resource_name       = "*"
+#   resource_type       = "Topic"
+#   acl_principal       = "User:CN=pubsub/msk-data-keep-restore"
+#   acl_host            = "*"
+#   acl_operation       = "Write"
+#   acl_permission_type = "Allow"
+# }
+
+# Needed for determining the resume point
+# resource "kafka_acl" "msk_data_keep_restore_read_topic_all" {
+#   resource_name       = "*"
+#   resource_type       = "Topic"
+#   acl_principal       = "User:CN=pubsub/msk-data-keep-restore"
+#   acl_host            = "*"
+#   acl_operation       = "Read"
+#   acl_permission_type = "Allow"
+# }
+
+# resource "kafka_acl" "msk_data_keep_restore_write_groups_all" {
+#   resource_name                = "*"
+#   resource_type                = "Group"
+#   acl_principal                = "User:CN=pubsub/msk-data-keep-restore"
+#   acl_host                     = "*"
+#   # this is non intuitive... we need the Read permission to be able to commit offsets on groups
+#   acl_operation                = "Read"
+#   acl_permission_type          = "Allow"
+# }

--- a/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-test.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-test.tf
@@ -1,38 +1,16 @@
-resource "kafka_acl" "msk_data_keep_backup_read_topic_all" {
-  resource_name       = "*"
-  resource_type       = "Topic"
-  acl_principal       = "User:CN=pubsub/msk-data-keep-backup"
-  acl_host            = "*"
-  acl_operation       = "Read"
-  acl_permission_type = "Allow"
-}
-
-resource "kafka_acl" "msk_data_keep_backup_describe_group_all" {
-  resource_name       = "*"
-  resource_type       = "Group"
-  acl_principal       = "User:CN=pubsub/msk-data-keep-backup"
-  acl_host            = "*"
-  acl_operation       = "Describe"
-  acl_permission_type = "Allow"
-}
-
-module "msk_data_keep_backup" {
-  source           = "../../../modules/tls-app"
-  consume_groups   = ["pubsub.msk-data-keep-backup"]
-  cert_common_name = "pubsub/msk-data-keep-backup"
-}
-
 ################################################################
-# Enable this part when we need to do a FULL cluster restore or we need to test the restore app on the EXISTING DEV cluster.
-# Contains the plan restore topics part.
+# Enable this configuration when we need to test the restore app on the EXISTING DEV cluster.
+# It gives permissions for the restore app to test topics and consumer groups that are prefixed with "pubsub.restore-test."
+# The auth.iam-identitydb-v1 has been chosen as a test topic since it has a small amount of data both in dev and prod.
 ################################################################
+
 # resource "kafka_topic" "plan_restore_normal" {
 #   name               = "pubsub.plan-topic-restore.normal"
 #   replication_factor = 3
 #   partitions         = 15
 #   config = {
 #     "remote.storage.enable" = "true"
-#     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
+#     "local.retention.ms"    = "86400000" # keep data
 #     # keep data for 3 days
 #     "retention.ms" = "259200000"
 #     # allow for a batch of records maximum 100MiB
@@ -65,66 +43,6 @@ module "msk_data_keep_backup" {
 #
 #   cert_common_name = "pubsub/msk-data-keep-plan-restore"
 # }
-
-################################################################
-# End of the common section for doing a FULL cluster restore or testing the restore app on the EXISTING DEV cluster.
-################################################################
-
-
-################################################################
-# Enable this part only when we need to do a FULL cluster restore.
-# It gives permissions for the restore app fully on all topics
-################################################################
-
-# module "msk_data_keep_restore" {
-#   source         = "../../../modules/tls-app"
-#   consume_groups = ["pubsub.msk-data-keep-restore.normal", "pubsub.msk-data-keep-restore.large"]
-#   consume_topics = [kafka_topic.plan_restore_normal.name, kafka_topic.plan_restore_large.name]
-#
-#   cert_common_name = "pubsub/msk-data-keep-restore"
-# }
-
-#
-# resource "kafka_acl" "msk_data_keep_restore_write_topic_all" {
-#   resource_name       = "*"
-#   resource_type       = "Topic"
-#   acl_principal       = "User:CN=pubsub/msk-data-keep-restore"
-#   acl_host            = "*"
-#   acl_operation       = "Write"
-#   acl_permission_type = "Allow"
-# }
-
-# Needed for determining the resume point
-# resource "kafka_acl" "msk_data_keep_restore_read_topic_all" {
-#   resource_name       = "*"
-#   resource_type       = "Topic"
-#   acl_principal       = "User:CN=pubsub/msk-data-keep-restore"
-#   acl_host            = "*"
-#   acl_operation       = "Read"
-#   acl_permission_type = "Allow"
-# }
-
-# resource "kafka_acl" "msk_data_keep_restore_write_groups_all" {
-#   resource_name                = "*"
-#   resource_type                = "Group"
-#   acl_principal                = "User:CN=pubsub/msk-data-keep-restore"
-#   acl_host                     = "*"
-#   # this is non intuitive... we need the Read permission to be able to commit offsets on groups
-#   acl_operation                = "Read"
-#   acl_permission_type          = "Allow"
-# }
-
-
-################################################################
-# End of the section for a FULL cluster restore.
-################################################################
-
-
-################################################################
-# Enable this part when we need to test the restore app on the EXISTING DEV cluster.
-# It gives permissions for the restore app only on a test topic that we use for restoring.
-# The auth.iam-identitydb-v1 has been chosen as it has a small amount of data both in dev and prod.
-################################################################
 
 # resource "kafka_topic" "restore_test_topic" {
 #   name               = "pubsub.restore-test.auth.iam-identitydb-v1"
@@ -184,7 +102,3 @@ module "msk_data_keep_backup" {
 #   acl_permission_type          = "Allow"
 #   resource_pattern_type_filter = "Prefixed"
 # }
-
-################################################################
-# End of the section for testing the restore app on the EXISTING DEV cluster.
-################################################################

--- a/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-test.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-test.tf
@@ -10,7 +10,7 @@
 #   partitions         = 15
 #   config = {
 #     "remote.storage.enable" = "true"
-#     "local.retention.ms"    = "86400000" # keep data
+#     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
 #     # keep data for 3 days
 #     "retention.ms" = "259200000"
 #     # allow for a batch of records maximum 100MiB

--- a/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-test.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-test.tf
@@ -4,101 +4,106 @@
 # The auth.iam-identitydb-v1 has been chosen as a test topic since it has a small amount of data both in dev and prod.
 ################################################################
 
-# resource "kafka_topic" "plan_restore_normal" {
-#   name               = "pubsub.plan-topic-restore.normal"
-#   replication_factor = 3
-#   partitions         = 15
-#   config = {
-#     "remote.storage.enable" = "true"
-#     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
-#     # keep data for 3 days
-#     "retention.ms" = "259200000"
-#     # allow for a batch of records maximum 100MiB
-#     "max.message.bytes" = "104857600"
-#     "compression.type"  = "zstd"
-#     "cleanup.policy"    = "delete"
-#   }
-# }
-#
-# resource "kafka_topic" "plan_restore_large" {
-#   name               = "pubsub.plan-topic-restore.large"
-#   replication_factor = 3
-#   partitions         = 15
-#   config = {
-#     "remote.storage.enable" = "true"
-#     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
-#     # keep data for 3 days
-#     "retention.ms" = "259200000"
-#     # allow for a batch of records maximum 100MiB
-#     "max.message.bytes" = "104857600"
-#     "compression.type"  = "zstd"
-#     "cleanup.policy"    = "delete"
-#   }
-# }
-#
-# module "msk_data_keep_plan_restore" {
-#   source         = "../../../modules/tls-app"
-#   produce_topics = [kafka_topic.plan_restore_normal.name, kafka_topic.plan_restore_large.name]
-#   consume_topics = [kafka_topic.plan_restore_normal.name, kafka_topic.plan_restore_large.name]
-#
-#   cert_common_name = "pubsub/msk-data-keep-plan-restore"
-# }
+#  Use a variable to enable or disable restore test resources.
+#  This allows us to keep the configuration in place for when we need it, without having to rely on git history to bring it back.
+variable "enable_restore_test" {
+  type        = bool
+  description = "Set to true to enable restore test resources, false to disable them."
+  default     = false
+}
+resource "kafka_topic" "plan_restore_test_normal" {
+  count              = var.enable_restore_test ? 1 : 0
+  name               = "pubsub.plan-topic-restore.normal"
+  replication_factor = 3
+  partitions         = 5
+  config = {
+    "remote.storage.enable" = "true"
+    "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
+    # keep data for 3 days
+    "retention.ms" = "259200000"
+    # allow for a batch of records maximum 100MiB
+    "max.message.bytes" = "104857600"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
 
-# resource "kafka_topic" "restore_test_topic" {
-#   name               = "pubsub.restore-test.auth.iam-identitydb-v1"
-#   replication_factor = 3
-#   # MUST be 1 partition as identitydb assumes this to be true
-#   partitions = 1
-#   config = {
-#     # Use tiered storage
-#     "remote.storage.enable" = "true"
-#     # keep on each partition 100MiB
-#     "retention.bytes" = "104857600"
-#     # keep data for 1 month
-#     "retention.ms" = "2592000000"
-#     # keep data in primary storage for 2 days
-#     "local.retention.ms" = "172800000"
-#     # allow for a batch of records maximum 5MiB
-#     "max.message.bytes" = "5242880"
-#     "compression.type"  = "zstd"
-#     "cleanup.policy"    = "delete"
-#   }
-# }
-#
-# module "msk_data_keep_restore" {
-#   source           = "../../../modules/tls-app"
-#   consume_groups   = ["pubsub.msk-data-keep-restore.normal", "pubsub.msk-data-keep-restore.large"]
-#   consume_topics   = [kafka_topic.plan_restore_normal.name, kafka_topic.plan_restore_large.name]
-#   cert_common_name = "pubsub/msk-data-keep-restore"
-# }
-#
-# resource "kafka_acl" "msk_data_keep_restore_read_restore_topics" {
-#   resource_name                = "pubsub.restore-test."
-#   resource_type                = "Topic"
-#   acl_principal                = "User:CN=pubsub/msk-data-keep-restore"
-#   acl_host                     = "*"
-#   acl_operation                = "Read"
-#   acl_permission_type          = "Allow"
-#   resource_pattern_type_filter = "Prefixed"
-# }
-#
-# resource "kafka_acl" "msk_data_keep_restore_write_restore_topics" {
-#   resource_name                = "pubsub.restore-test."
-#   resource_type                = "Topic"
-#   acl_principal                = "User:CN=pubsub/msk-data-keep-restore"
-#   acl_host                     = "*"
-#   acl_operation                = "Write"
-#   acl_permission_type          = "Allow"
-#   resource_pattern_type_filter = "Prefixed"
-# }
-#
-# resource "kafka_acl" "msk_data_keep_restore_write_restore_groups" {
-#   resource_name = "pubsub.restore-test."
-#   resource_type = "Group"
-#   acl_principal = "User:CN=pubsub/msk-data-keep-restore"
-#   acl_host      = "*"
-#   # this is non intuitive... we need the Read permission to be able to commit offsets on groups
-#   acl_operation                = "Read"
-#   acl_permission_type          = "Allow"
-#   resource_pattern_type_filter = "Prefixed"
-# }
+resource "kafka_topic" "plan_restore_test_large" {
+  count              = var.enable_restore_test ? 1 : 0
+  name               = "pubsub.plan-topic-restore.large"
+  replication_factor = 3
+  partitions         = 5
+  config = {
+    "remote.storage.enable" = "true"
+    "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
+    # keep data for 3 days
+    "retention.ms" = "259200000"
+    # allow for a batch of records maximum 100MiB
+    "max.message.bytes" = "104857600"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+resource "kafka_topic" "restore_test_topic" {
+  count              = var.enable_restore_test ? 1 : 0
+  name               = "pubsub.restore-test.auth.iam-identitydb-v1"
+  replication_factor = 3
+  # MUST be 1 partition as identitydb assumes this to be true
+  partitions = 1
+  config = {
+    # Use tiered storage
+    "remote.storage.enable" = "true"
+    # keep on each partition 100MiB
+    "retention.bytes" = "104857600"
+    # keep data for 1 month
+    "retention.ms" = "2592000000"
+    # keep data in primary storage for 2 days
+    "local.retention.ms" = "172800000"
+    # allow for a batch of records maximum 5MiB
+    "max.message.bytes" = "5242880"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+module "msk_data_keep_restore" {
+  count            = var.enable_restore_test ? 1 : 0
+  source           = "../../../modules/tls-app"
+  consume_groups   = ["pubsub.msk-data-keep-restore.normal", "pubsub.msk-data-keep-restore.large"]
+  consume_topics   = ["pubsub.plan-topic-restore.large", "pubsub.plan-topic-restore.normal"]
+  cert_common_name = "pubsub/msk-data-keep-restore"
+}
+
+resource "kafka_acl" "msk_data_keep_restore_read_restore_test_topics" {
+  count                        = var.enable_restore_test ? 1 : 0
+  resource_name                = "pubsub.restore-test."
+  resource_type                = "Topic"
+  acl_principal                = "User:CN=pubsub/msk-data-keep-restore"
+  acl_host                     = "*"
+  acl_operation                = "Read"
+  acl_permission_type          = "Allow"
+  resource_pattern_type_filter = "Prefixed"
+}
+
+resource "kafka_acl" "msk_data_keep_restore_write_restore_test_topics" {
+  count                        = var.enable_restore_test ? 1 : 0
+  resource_name                = "pubsub.restore-test."
+  resource_type                = "Topic"
+  acl_principal                = "User:CN=pubsub/msk-data-keep-restore"
+  acl_host                     = "*"
+  acl_operation                = "Write"
+  acl_permission_type          = "Allow"
+  resource_pattern_type_filter = "Prefixed"
+}
+
+resource "kafka_acl" "msk_data_keep_restore_write_restore_test_groups" {
+  count         = var.enable_restore_test ? 1 : 0
+  resource_name = "pubsub.restore-test."
+  resource_type = "Group"
+  acl_principal = "User:CN=pubsub/msk-data-keep-restore"
+  acl_host      = "*"
+  # this is non intuitive... we need the Read permission to be able to commit offsets on groups
+  acl_operation                = "Read"
+  acl_permission_type          = "Allow"
+  resource_pattern_type_filter = "Prefixed"
+}


### PR DESCRIPTION
Split into backup and restore.
Suppress the resources in each case by using a variable that is by default on false.
Enabling it will create the resource.