### PR TITLE
fix: replace plain __env.tf with symlink in prod-aws/kafka-shared-msk/unicom

### DIFF
--- a/prod-aws/kafka-shared-msk/unicom/__env.tf
+++ b/prod-aws/kafka-shared-msk/unicom/__env.tf
@@ -1,18 +1,1 @@
-terraform {
-  required_version = ">= 1.5.0"
-
-  required_providers {
-    kafka = {
-      source  = "Mongey/kafka"
-      version = ">= 0.7.0"
-    }
-  }
-}
-
-provider "kafka" {
-  bootstrap_servers = [
-    "b-1.devenablementpubsubmsk.mw71ue.c2.kafka.eu-west-1.amazonaws.com:9094",
-    "b-2.devenablementpubsubmsk.mw71ue.c2.kafka.eu-west-1.amazonaws.com:9094",
-    "b-3.devenablementpubsubmsk.mw71ue.c2.kafka.eu-west-1.amazonaws.com:9094",
-  ]
-}
+../__env.tf


### PR DESCRIPTION
## Summary

- `prod-aws/kafka-shared-msk/unicom/__env.tf` was a plain file (duplicate of the parent `__env.tf`) instead of a symlink, inconsistent with all other submodules under `kafka-shared-msk`
- Replaced with a symlink pointing to `../__env.tf`, matching the pattern used everywhere else