### PR TITLE
fix: rename gentrack-agreements-consumer to gentrack-agreement-consumer

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -207,9 +207,9 @@ module "energy_service_gentrack_registration_consumer" {
 }
 
 
-module "energy_service_gentrack_agreements_consumer" {
+module "energy_service_gentrack_agreement_consumer" {
   source           = "../../../modules/tls-app"
   consume_topics   = [kafka_topic.gentrack_agreement_events.name]
-  consume_groups   = ["energy-platform.services-gentrack-agreements-consumer"]
-  cert_common_name = "energy-platform/services-gentrack-agreements-consumer"
+  consume_groups   = ["energy-platform.services-gentrack-agreement-consumer"]
+  cert_common_name = "energy-platform/services-gentrack-agreement-consumer"
 }

--- a/prod-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/prod-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -206,9 +206,9 @@ module "energy_service_gentrack_registration_consumer" {
   cert_common_name = "energy-platform/services-gentrack-registration-consumer"
 }
 
-module "energy_service_gentrack_agreements_consumer" {
+module "energy_service_gentrack_agreement_consumer" {
   source           = "../../../modules/tls-app"
   consume_topics   = [kafka_topic.gentrack_agreement_events.name]
-  consume_groups   = ["energy-platform.services-gentrack-agreements-consumer"]
-  cert_common_name = "energy-platform/services-gentrack-agreements-consumer"
+  consume_groups   = ["energy-platform.services-gentrack-agreement-consumer"]
+  cert_common_name = "energy-platform/services-gentrack-agreement-consumer"
 }


### PR DESCRIPTION
### Overview

Fixes a naming mismatch with the consumer that is preventing the consumer having access to the topic