### PR TITLE
Adding kafka topic  and webhook processor

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -149,6 +149,21 @@ resource "kafka_topic" "gentrack_agreement_events" {
   }
 }
 
+resource "kafka_topic" "gentrack_prepayment_change_of_mode_events" {
+  name               = "energy-platform.gentrack.prepayment.change_of_mode.events"
+  replication_factor = 3
+  partitions         = 15
+
+  config = {
+    "remote.storage.enable" = "true"
+    "retention.ms"          = "15552000000"
+    "local.retention.ms"    = "172800000"
+    "max.message.bytes"     = "1048576"
+    "compression.type"      = "zstd"
+    "cleanup.policy"        = "delete"
+  }
+}
+
 module "gentrack_adapter_webhook_processor" {
   source = "../../../modules/tls-app"
   produce_topics = [
@@ -159,7 +174,8 @@ module "gentrack_adapter_webhook_processor" {
     kafka_topic.gentrack_meterpoint_events.name,
     kafka_topic.gentrack_electronic_payment_events.name,
     kafka_topic.gentrack_prepayment_events.name,
-    kafka_topic.gentrack_agreement_events.name
+    kafka_topic.gentrack_agreement_events.name,
+    kafka_topic.gentrack_prepayment_change_of_mode_events.name
   ]
   cert_common_name = "energy-platform/gentrack-adapter-webhook-processor"
 }

--- a/dev-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
+++ b/dev-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
@@ -709,6 +709,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "msk_topics_retention" {
   }
 
   rule {
+    id     = "energy-platform.gentrack.prepayment.change_of_mode.events"
+    status = "Enabled"
+    expiration { days = 181 }
+    filter { prefix = "kafka-backup/energy-platform.gentrack.prepayment.change_of_mode.events/" }
+  }
+
+  rule {
     id     = "energy-platform.gentrack.prepayment.events"
     status = "Enabled"
     expiration { days = 181 }


### PR DESCRIPTION
Adding the adapter for the new events added to energy-contract

Part of the following task: https://linear.app/utilitywarehouse/issue/EPTF-116/task-define-proto-contracts-for-the-change-of-mode-events-in-energy