### PR TITLE
Permissions update for Energy Billing Consumer.

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/properties.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/properties.tf
@@ -49,6 +49,7 @@ module "energy_billing_consumer" {
   consume_topics = [
     kafka_topic.property_migration_events.name,
     kafka_topic.gentrack_electronic_payment_events.name,
+    kafka_topic.property_events.name,
   ]
   consume_groups   = ["energy-billing.budget-plan-events-consumer"]
   cert_common_name = "energy-billing/budget-plan-events-consumer"

--- a/prod-aws/kafka-shared-msk/energy-platform/properties.tf
+++ b/prod-aws/kafka-shared-msk/energy-platform/properties.tf
@@ -47,6 +47,7 @@ module "energy_billing_consumer" {
   consume_topics = [
     kafka_topic.property_migration_events.name,
     kafka_topic.gentrack_electronic_payment_events.name,
+    kafka_topic.property_events.name,
   ]
   consume_groups   = ["energy-billing.budget-plan-events-consumer"]
   cert_common_name = "energy-billing/budget-plan-events-consumer"


### PR DESCRIPTION
Give Energy Billing Consumer permissions to consume `energy-platform.property.events` in `prod-aws` and `dev-aws`.