### PR TITLE
Add Kafka resources for claudetest onboarding

### DIFF
--- a/dev-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
+++ b/dev-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
@@ -807,6 +807,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "msk_topics_retention" {
   }
 
   rule {
+    id     = "onboarding.claudetest"
+    status = "Enabled"
+    expiration { days = 3 }
+    filter { prefix = "kafka-backup/onboarding.claudetest/" }
+  }
+
+  rule {
     id     = "onboarding.sbuliarca"
     status = "Enabled"
     expiration { days = 3 }

--- a/dev-aws/kafka-shared-msk/onboarding/claudetest-resources.tf
+++ b/dev-aws/kafka-shared-msk/onboarding/claudetest-resources.tf
@@ -1,0 +1,30 @@
+# Example topic
+resource "kafka_topic" "onboarding_topic_claudetest" {
+  name               = "onboarding.claudetest"
+  replication_factor = 3
+  partitions         = 2
+  config = {
+    # keep on each partition 10MiB
+    "retention.bytes" = "10485760"
+    # keep data for 2 days
+    "retention.ms" = "172800000"
+    # allow for a batch of records maximum 1MiB
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
+  }
+}
+
+# Example producer and consumer modules
+module "onboarding_producer_claudetest" {
+  source           = "../../../modules/tls-app"
+  produce_topics   = ["onboarding.claudetest"]
+  cert_common_name = "onboarding/producer-claudetest"
+}
+
+module "onboarding_consumer_claudetest" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = ["onboarding.claudetest"]
+  consume_groups   = ["onboarding.consumer-claudetest"]
+  cert_common_name = "onboarding/consumer-claudetest"
+}


### PR DESCRIPTION
## Summary
- Adds `onboarding.claudetest` topic (2 partitions, 3 replicas, 2-day retention)
- Adds producer TLS ACLs for `onboarding/producer-claudetest`
- Adds consumer TLS ACLs for `onboarding/consumer-claudetest` (consumer group `onboarding.consumer-claudetest`)

Part of the Kafka onboarding exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)