### PR TITLE
[EPTF-291]: Rename energy_prepayment_projector to energy_prepayment_consumer

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -189,14 +189,14 @@ module "billing_sqs_processor" {
   cert_common_name = "energy-billing/billing-sqs-processor"
 }
 
-module "energy_prepayment_projector" {
+module "energy_prepayment_consumer" {
   source = "../../../modules/tls-app"
   consume_topics = [
     kafka_topic.gentrack_prepayment_events.name,
     kafka_topic.gentrack_meterpoint_events.name
   ]
-  consume_groups   = ["energy-platform.prepayment-projector"]
-  cert_common_name = "energy-platform/prepayment-projector"
+  consume_groups   = ["energy-platform.prepayment-consumer"]
+  cert_common_name = "energy-platform/prepayment-consumer"
 }
 
 module "energy_service_gentrack_registration_consumer" {

--- a/prod-aws/kafka-shared-msk/energy-platform/gentrack.tf
+++ b/prod-aws/kafka-shared-msk/energy-platform/gentrack.tf
@@ -189,14 +189,14 @@ module "billing_sqs_processor" {
   cert_common_name = "energy-billing/billing-sqs-processor"
 }
 
-module "energy_prepayment_projector" {
+module "energy_prepayment_consumer" {
   source = "../../../modules/tls-app"
   consume_topics = [
     kafka_topic.gentrack_prepayment_events.name,
     kafka_topic.gentrack_meterpoint_events.name
   ]
-  consume_groups   = ["energy-platform.prepayment-projector"]
-  cert_common_name = "energy-platform/prepayment-projector"
+  consume_groups   = ["energy-platform.prepayment-consumer"]
+  cert_common_name = "energy-platform/prepayment-consumer"
 }
 
 module "energy_service_gentrack_registration_consumer" {


### PR DESCRIPTION
Related to:
1. https://github.com/utilitywarehouse/energy-prepayment/pull/147
2. https://github.com/utilitywarehouse/kubernetes-manifests/pull/129099
