### PR TITLE
Add ES indexer ACL for home-move lifecycle events topic (dev+prod)

### DIFF
--- a/dev-aws/kafka-shared-msk/account-identity/account.tf
+++ b/dev-aws/kafka-shared-msk/account-identity/account.tf
@@ -220,6 +220,13 @@ module "account_identity_account_insights_events_v4_indexer" {
   cert_common_name = "account-platform/account_insights_events_v4_indexer"
 }
 
+module "account_identity_home_move_lifecycle_events_v1_indexer" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = [kafka_topic.account_identity_home_move_lifecycle_events_v1.name]
+  consume_groups   = ["account-identity.home-move-lifecycle-events-v1-aws"]
+  cert_common_name = "account-platform/home_move_lifecycle_events_v1_indexer"
+}
+
 module "account_identity_account_api" {
   source           = "../../../modules/tls-app"
   produce_topics   = [kafka_topic.account_identity_account_atomic_v1.name, kafka_topic.account_identity_account_events_v2.name]

--- a/prod-aws/kafka-shared-msk/account-identity/account.tf
+++ b/prod-aws/kafka-shared-msk/account-identity/account.tf
@@ -338,6 +338,13 @@ module "account_identity_account_insights_events_v4_indexer" {
   cert_common_name = "account-platform/account_insights_events_v4_indexer"
 }
 
+module "account_identity_home_move_lifecycle_events_v1_indexer" {
+  source           = "../../../modules/tls-app"
+  consume_topics   = [kafka_topic.account_identity_home_move_lifecycle_events_v1.name]
+  consume_groups   = ["account-identity.home-move-lifecycle-events-v1-aws"]
+  cert_common_name = "account-platform/home_move_lifecycle_events_v1_indexer"
+}
+
 module "account_identity_account_events_v3_indexer" {
   source           = "../../../modules/tls-app"
   consume_topics   = [kafka_topic.account_identity_account_events_v3.name]


### PR DESCRIPTION
Grants the home-move-lifecycle-events-v1 indexer read access to the account-identity.home-move.lifecycle.events.v1 topic and its consumer group, mirroring the existing account-insights-events-v4 indexer ACL.