### PR TITLE
feat: add flow file events topic

### DIFF
--- a/dev-aws/kafka-shared-msk/energy-platform/flow_files.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/flow_files.tf
@@ -1,0 +1,19 @@
+resource "kafka_topic" "flow_files_events" {
+  name               = "energy-platform.flow-files.events"
+  replication_factor = 3
+  partitions         = 3
+  config = {
+    "remote.storage.enable" = "true"
+    "retention.ms"          = "2592000000"
+    "local.retention.ms"    = "172800000"
+    "max.message.bytes"     = "1048576"
+    "compression.type"      = "zstd"
+    "cleanup.policy"        = "delete"
+  }
+}
+
+module "energy_flows_notification_outbox" {
+  source           = "../../../modules/tls-app"
+  produce_topics   = [kafka_topic.flow_files_events.name]
+  cert_common_name = "energy-platform/energy-flows-notification-outbox"
+}

--- a/dev-aws/kafka-shared-msk/energy-platform/flow_files.tf
+++ b/dev-aws/kafka-shared-msk/energy-platform/flow_files.tf
@@ -3,12 +3,16 @@ resource "kafka_topic" "flow_files_events" {
   replication_factor = 3
   partitions         = 3
   config = {
+    # Use tiered storage
     "remote.storage.enable" = "true"
-    "retention.ms"          = "2592000000"
-    "local.retention.ms"    = "172800000"
-    "max.message.bytes"     = "1048576"
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    # keep data for 1 month
+    "retention.ms" = "2592000000"
+    # keep data in primary storage for 2 days
+    "local.retention.ms" = "172800000"
+    # allow for a batch of records maximum 1MiB
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
   }
 }
 

--- a/dev-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
+++ b/dev-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
@@ -688,6 +688,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "msk_topics_retention" {
   }
 
   rule {
+    id     = "energy-platform.flow-files.events"
+    status = "Enabled"
+    expiration { days = 31 }
+    filter { prefix = "kafka-backup/energy-platform.flow-files.events/" }
+  }
+
+  rule {
     id     = "energy-platform.gentrack.billing.events"
     status = "Enabled"
     expiration { days = 31 }

--- a/prod-aws/kafka-shared-msk/energy-platform/flow_files.tf
+++ b/prod-aws/kafka-shared-msk/energy-platform/flow_files.tf
@@ -1,0 +1,19 @@
+resource "kafka_topic" "flow_files_events" {
+  name               = "energy-platform.flow-files.events"
+  replication_factor = 3
+  partitions         = 3
+  config = {
+    "remote.storage.enable" = "true"
+    "retention.ms"          = "2592000000"
+    "local.retention.ms"    = "172800000"
+    "max.message.bytes"     = "1048576"
+    "compression.type"      = "zstd"
+    "cleanup.policy"        = "delete"
+  }
+}
+
+module "energy_flows_notification_outbox" {
+  source           = "../../../modules/tls-app"
+  produce_topics   = [kafka_topic.flow_files_events.name]
+  cert_common_name = "energy-platform/energy-flows-notification-outbox"
+}

--- a/prod-aws/kafka-shared-msk/energy-platform/flow_files.tf
+++ b/prod-aws/kafka-shared-msk/energy-platform/flow_files.tf
@@ -3,12 +3,16 @@ resource "kafka_topic" "flow_files_events" {
   replication_factor = 3
   partitions         = 3
   config = {
+    # Use tiered storage
     "remote.storage.enable" = "true"
-    "retention.ms"          = "2592000000"
-    "local.retention.ms"    = "172800000"
-    "max.message.bytes"     = "1048576"
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
+    # keep data for 1 month
+    "retention.ms" = "2592000000"
+    # keep data in primary storage for 2 days
+    "local.retention.ms" = "172800000"
+    # allow for a batch of records maximum 1MiB
+    "max.message.bytes" = "1048576"
+    "compression.type"  = "zstd"
+    "cleanup.policy"    = "delete"
   }
 }
 

--- a/prod-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
+++ b/prod-aws/kafka-shared-msk/msk-backup-bucket-retention/generated-retention.tf
@@ -653,6 +653,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "msk_topics_retention" {
   }
 
   rule {
+    id     = "energy-platform.flow-files.events"
+    status = "Enabled"
+    expiration { days = 31 }
+    filter { prefix = "kafka-backup/energy-platform.flow-files.events/" }
+  }
+
+  rule {
     id     = "energy-platform.gentrack.billing.events"
     status = "Enabled"
     expiration { days = 31 }


### PR DESCRIPTION
## Why

Energy Flows needs a durable Kafka topic for received-flow notifications.

## What

- Add the flow-file events topic in dev and prod.
- Grant the Energy Flows notification outbox producer-only access.

## Testing and validation

- Not run; Terraform generation remains to be performed.