### PR TITLE
precommit: remove the validate plugin as it is very slow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,13 +29,6 @@ repos:
         # https://github.com/antonbabenko/pre-commit-terraform?tab=readme-ov-file#terraform_tflint
         - --args=--format=default
       files: "^.*/kafka-shared-msk/.+/.*$"
-    - id: terraform_validate
-      args:
-        # for local cached .terraform folders. Explanations in https://github.com/antonbabenko/pre-commit-terraform?tab=readme-ov-file#terraform_validate
-        - --hook-config=--retry-once-with-cleanup=true
-        - --tf-init-args=-upgrade
-        # no backend
-        - --tf-init-args=-backend=false
 - repo: https://github.com/semgrep/pre-commit
   rev: 'v1.144.1'
   hooks:


### PR DESCRIPTION
The validate command takes a lot of time and we have the tf applier running on PRs that does the plan command which does more than validate.