### PR TITLE
Cap max.message.bytes to 3MB in dev kafka-shared-msk

### DIFF
--- a/dev-aws/kafka-shared-msk/billing/billing.tf
+++ b/dev-aws/kafka-shared-msk/billing/billing.tf
@@ -86,8 +86,8 @@ resource "kafka_topic" "billing_bill_core_model" {
     "retention.ms" = "2592000000"
     # delete old data
     "cleanup.policy" = "delete"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 

--- a/dev-aws/kafka-shared-msk/billing/data-staged-events.tf
+++ b/dev-aws/kafka-shared-msk/billing/data-staged-events.tf
@@ -6,8 +6,8 @@ resource "kafka_topic" "data_staged_events_finance" {
     "compression.type" = "zstd"
     # keep on each partition 750GiB
     "retention.bytes" = "805306368000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     # Use tiered storage
     "remote.storage.enable" = "true"
     # keep data in primary storage for 2 days
@@ -25,8 +25,8 @@ resource "kafka_topic" "historical_data_staged_events_finance" {
     "compression.type" = "zstd"
     # keep on each partition 750GiB
     "retention.bytes" = "805306368000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     # Use tiered storage
     "remote.storage.enable" = "true"
     # keep data in primary storage for 2 days

--- a/dev-aws/kafka-shared-msk/billing/transaction-auditor-events.tf
+++ b/dev-aws/kafka-shared-msk/billing/transaction-auditor-events.tf
@@ -6,8 +6,8 @@ resource "kafka_topic" "transactions_auditor_diff_events" {
     "compression.type" = "zstd"
     # keep on each partition 750GiB
     "retention.bytes" = "805306368000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     # Use tiered storage
     "remote.storage.enable" = "true"
     # keep data in primary storage for 2 days

--- a/dev-aws/kafka-shared-msk/billing/transaction-log.tf
+++ b/dev-aws/kafka-shared-msk/billing/transaction-log.tf
@@ -13,7 +13,7 @@ resource "kafka_topic" "billing_transaction_log_v3" {
     "retention.ms" = "2764800000"
     # making sure cleanup policy is not compaction
     "cleanup.policy" = "delete"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }

--- a/dev-aws/kafka-shared-msk/contact-channels/contact-channels.tf
+++ b/dev-aws/kafka-shared-msk/contact-channels/contact-channels.tf
@@ -8,7 +8,7 @@ resource "kafka_topic" "genesys_eb_events" {
     "remote.storage.enable" = "true"
     "local.retention.ms"    = "259200000"  # keep data in primary storage for 3 days
     "retention.ms"          = "2629800000" # keep data for 1 month
-    "max.message.bytes"     = "104857600"  # allow for a batch of records maximum 100MiB
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MiB
     "compression.type"      = "zstd"
     "cleanup.policy"        = "delete"
   }
@@ -164,7 +164,7 @@ resource "kafka_topic" "dsar" {
     "remote.storage.enable" = "true"
     "local.retention.ms"    = "259200000"  # keep data in primary storage for 3 days
     "retention.ms"          = "2629800000" # keep data for 1 month
-    "max.message.bytes"     = "104857600"  # allow for a batch of records maximum 100MiB
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MiB
     "compression.type"      = "zstd"
     "cleanup.policy"        = "delete"
   }
@@ -180,7 +180,7 @@ resource "kafka_topic" "dsar_job" {
     "remote.storage.enable" = "true"
     "local.retention.ms"    = "259200000"  # keep data in primary storage for 3 days
     "retention.ms"          = "2629800000" # keep data for 1 month
-    "max.message.bytes"     = "104857600"  # allow for a batch of records maximum 100MiB
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MiB
     "compression.type"      = "zstd"
     "cleanup.policy"        = "delete"
   }
@@ -196,7 +196,7 @@ resource "kafka_topic" "dsar_conversation" {
     "remote.storage.enable" = "true"
     "local.retention.ms"    = "259200000"  # keep data in primary storage for 3 days
     "retention.ms"          = "2629800000" # keep data for 1 month
-    "max.message.bytes"     = "104857600"  # allow for a batch of records maximum 100MiB
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MiB
     "compression.type"      = "zstd"
     "cleanup.policy"        = "delete"
   }
@@ -212,7 +212,7 @@ resource "kafka_topic" "auto_email_drafts" {
     "remote.storage.enable" = "true"
     "local.retention.ms"    = "259200000"  # keep data in primary storage for 3 days
     "retention.ms"          = "2629800000" # keep data for 1 month
-    "max.message.bytes"     = "104857600"  # allow for a batch of records maximum 100MiB
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MiB
     "compression.type"      = "zstd"
     "cleanup.policy"        = "delete"
   }

--- a/dev-aws/kafka-shared-msk/customer-billing/topics.tf
+++ b/dev-aws/kafka-shared-msk/customer-billing/topics.tf
@@ -127,8 +127,8 @@ resource "kafka_topic" "bex_legacy_invoice_api" {
     "local.retention.ms" = "86400000"
     # keep data for 7 days
     "retention.ms" = "604800000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }
@@ -161,7 +161,7 @@ resource "kafka_topic" "transition_bex_fulfilment_request" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 1 day
     "local.retention.ms" = "86400000"
-    "max.message.bytes"  = "104857600" # allow for a batch of records maximum 100MiB
+    "max.message.bytes"  = "3145728" # allow for a batch of records maximum 3MiB
     "compression.type"   = "zstd"
     "cleanup.policy"     = "delete"
     # keep data for 7 days

--- a/dev-aws/kafka-shared-msk/iam/iam.tf
+++ b/dev-aws/kafka-shared-msk/iam/iam.tf
@@ -194,8 +194,8 @@ resource "kafka_topic" "iam_identitydb_v1" {
     "retention.ms" = "2592000000"
     # keep data in primary storage for 2 days
     "local.retention.ms" = "172800000"
-    # allow for a batch of records maximum 5MiB
-    "max.message.bytes" = "5242880"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }

--- a/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-full-cluster.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-full-cluster.tf
@@ -21,8 +21,8 @@ resource "kafka_topic" "plan_restore_full" {
     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
     # keep data for 3 days
     "retention.ms" = "259200000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }

--- a/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-test.tf
+++ b/dev-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-test.tf
@@ -21,8 +21,8 @@ resource "kafka_topic" "plan_restore_test" {
     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
     # keep data for 3 days
     "retention.ms" = "259200000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }
@@ -43,8 +43,8 @@ resource "kafka_topic" "restore_test_topic" {
     "retention.ms" = "2592000000"
     # keep data in primary storage for 2 days
     "local.retention.ms" = "172800000"
-    # allow for a batch of records maximum 5MiB
-    "max.message.bytes" = "5242880"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }

--- a/dev-aws/kafka-shared-msk/staging-ept/data-staged-events.tf
+++ b/dev-aws/kafka-shared-msk/staging-ept/data-staged-events.tf
@@ -6,8 +6,8 @@ resource "kafka_topic" "data_staged_events_finance" {
     "compression.type" = "zstd"
     # keep on each partition 750GiB
     "retention.bytes" = "805306368000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     # Use tiered storage
     "remote.storage.enable" = "true"
     # keep data in primary storage for 2 days
@@ -25,8 +25,8 @@ resource "kafka_topic" "historical_data_staged_events_finance" {
     "compression.type" = "zstd"
     # keep on each partition 750GiB
     "retention.bytes" = "805306368000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     # Use tiered storage
     "remote.storage.enable" = "true"
     # keep data in primary storage for 2 days

--- a/dev-aws/kafka-shared-msk/staging-ept/transaction-auditor-events.tf
+++ b/dev-aws/kafka-shared-msk/staging-ept/transaction-auditor-events.tf
@@ -6,8 +6,8 @@ resource "kafka_topic" "transactions_auditor_diff_events" {
     "compression.type" = "zstd"
     # keep on each partition 750GiB
     "retention.bytes" = "805306368000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     # Use tiered storage
     "remote.storage.enable" = "true"
     # keep data in primary storage for 2 days

--- a/dev-aws/kafka-shared-msk/unicom/topics.tf
+++ b/dev-aws/kafka-shared-msk/unicom/topics.tf
@@ -12,8 +12,8 @@ resource "kafka_topic" "unicom_bill_events" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -31,8 +31,8 @@ resource "kafka_topic" "unicom_bill_failed" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -50,8 +50,8 @@ resource "kafka_topic" "unicom_bounce_2019_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -69,8 +69,8 @@ resource "kafka_topic" "unicom_caps" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -88,8 +88,8 @@ resource "kafka_topic" "unicom_caps_consent" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -107,8 +107,8 @@ resource "kafka_topic" "unicom_failed" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -126,8 +126,8 @@ resource "kafka_topic" "unicom_cancel_status_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -145,8 +145,8 @@ resource "kafka_topic" "unicom_cancellation_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -164,8 +164,8 @@ resource "kafka_topic" "unicom_clx_report" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -183,8 +183,8 @@ resource "kafka_topic" "unicom_comms_fallback_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -202,8 +202,8 @@ resource "kafka_topic" "unicom_cost_calculated_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -221,8 +221,8 @@ resource "kafka_topic" "unicom_email_batch_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -240,8 +240,8 @@ resource "kafka_topic" "unicom_email_post_delivery_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -259,8 +259,8 @@ resource "kafka_topic" "unicom_email_released_critical_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -278,8 +278,8 @@ resource "kafka_topic" "unicom_email_released_important_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -297,8 +297,8 @@ resource "kafka_topic" "unicom_email_released_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -316,8 +316,8 @@ resource "kafka_topic" "unicom_email_released_mock_critical_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -335,8 +335,8 @@ resource "kafka_topic" "unicom_email_released_mock_important_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -354,8 +354,8 @@ resource "kafka_topic" "unicom_email_released_mock_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -373,8 +373,8 @@ resource "kafka_topic" "unicom_email_released_ses_critical_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -392,8 +392,8 @@ resource "kafka_topic" "unicom_email_released_ses_important_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -411,8 +411,8 @@ resource "kafka_topic" "unicom_email_released_ses_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -430,8 +430,8 @@ resource "kafka_topic" "unicom_email_status_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -449,8 +449,8 @@ resource "kafka_topic" "unicom_push_notification_status_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -468,8 +468,8 @@ resource "kafka_topic" "unicom_go_inspire_letter_status_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -487,8 +487,8 @@ resource "kafka_topic" "unicom_letter_batch_critical_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -506,8 +506,8 @@ resource "kafka_topic" "unicom_letter_batch_important_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -525,8 +525,8 @@ resource "kafka_topic" "unicom_letter_batch_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -544,8 +544,8 @@ resource "kafka_topic" "unicom_letter_released_critical_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -563,8 +563,8 @@ resource "kafka_topic" "unicom_letter_released_important_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -582,8 +582,8 @@ resource "kafka_topic" "unicom_letter_released_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -601,8 +601,8 @@ resource "kafka_topic" "unicom_letter_released_mock_critical_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -620,8 +620,8 @@ resource "kafka_topic" "unicom_letter_released_mock_important_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -639,8 +639,8 @@ resource "kafka_topic" "unicom_letter_released_mock_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -658,8 +658,8 @@ resource "kafka_topic" "unicom_letter_status_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -677,8 +677,8 @@ resource "kafka_topic" "unicom_mparticle_output_integration" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -696,8 +696,8 @@ resource "kafka_topic" "unicom_orchestration_entity_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -715,8 +715,8 @@ resource "kafka_topic" "unicom_orchestration_rule_execution_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -734,8 +734,8 @@ resource "kafka_topic" "unicom_outbound_call_request" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -753,8 +753,8 @@ resource "kafka_topic" "unicom_rejected" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -772,8 +772,8 @@ resource "kafka_topic" "unicom_rendered_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -791,8 +791,8 @@ resource "kafka_topic" "unicom_requests" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -810,8 +810,8 @@ resource "kafka_topic" "unicom_scheduled_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -829,8 +829,8 @@ resource "kafka_topic" "unicom_send_notification_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -848,8 +848,8 @@ resource "kafka_topic" "unicom_sms_batch_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -867,8 +867,8 @@ resource "kafka_topic" "unicom_sms_released_critical_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -886,8 +886,8 @@ resource "kafka_topic" "unicom_sms_released_important_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -905,8 +905,8 @@ resource "kafka_topic" "unicom_sms_released_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -924,8 +924,8 @@ resource "kafka_topic" "unicom_sms_status_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -943,8 +943,8 @@ resource "kafka_topic" "unicom_status" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -962,8 +962,8 @@ resource "kafka_topic" "unicom_status_bill_email_connector" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -981,8 +981,8 @@ resource "kafka_topic" "unicom_status_energy_smets1_notifier" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -1000,8 +1000,8 @@ resource "kafka_topic" "unicom_status_finance_email_delivery_engine" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -1019,8 +1019,8 @@ resource "kafka_topic" "unicom_status_v2" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -1038,8 +1038,8 @@ resource "kafka_topic" "unicom_tests" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -1057,8 +1057,8 @@ resource "kafka_topic" "unicom_push_notification_released_1" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -1076,8 +1076,8 @@ resource "kafka_topic" "unicom_letter_send_adare" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -1112,8 +1112,8 @@ resource "kafka_topic" "unicom_comms_api_requests" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -1131,8 +1131,8 @@ resource "kafka_topic" "unicom_braze_backfill" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -1150,7 +1150,7 @@ resource "kafka_topic" "unicom_di_kafka_source_notification" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }


### PR DESCRIPTION
The MSK cluster is shared across teams, so a topic allowed to take larger messages lets one producer inflate broker memory, replication traffic, and disk I/O in a way that degrades every other topic on the cluster. Keeping a single, uniform cap is what lets us reason about capacity and avoid one team's traffic pattern causing a noisy-neighbour incident for everyone else.

We are enforcing a hard limit of 3MB across all topics. We checked that so far no apps are producing messages larger than 1MB, so this is a safe ceiling.

This is a companion PR to the prod change, both driven by the precondition documented at https://github.com/utilitywarehouse/documentation/blob/master/tech_stack/kafka/msk-migration.md#precondition