### PR TITLE
Cap max.message.bytes to 3MB in prod kafka-shared-msk

### DIFF
--- a/prod-aws/kafka-shared-msk/billing/billing.tf
+++ b/prod-aws/kafka-shared-msk/billing/billing.tf
@@ -86,8 +86,8 @@ resource "kafka_topic" "billing_bill_core_model" {
     "retention.ms" = "2592000000"
     # delete old data
     "cleanup.policy" = "delete"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 

--- a/prod-aws/kafka-shared-msk/billing/data-staged-events.tf
+++ b/prod-aws/kafka-shared-msk/billing/data-staged-events.tf
@@ -6,8 +6,8 @@ resource "kafka_topic" "data_staged_events_finance" {
     "compression.type" = "zstd"
     # keep on each partition 25GiB
     "retention.bytes" = "26843545600"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     # Use tiered storage
     "remote.storage.enable" = "true"
     # keep data in primary storage for 2 days
@@ -25,8 +25,8 @@ resource "kafka_topic" "historical_data_staged_events_finance" {
     "compression.type" = "zstd"
     # keep on each partition 750GiB
     "retention.bytes" = "805306368000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     # Use tiered storage
     "remote.storage.enable" = "true"
     # keep data in primary storage for 2 days

--- a/prod-aws/kafka-shared-msk/billing/transaction-auditor-events.tf
+++ b/prod-aws/kafka-shared-msk/billing/transaction-auditor-events.tf
@@ -6,8 +6,8 @@ resource "kafka_topic" "transactions_auditor_diff_events" {
     "compression.type" = "zstd"
     # keep on each partition 750GiB
     "retention.bytes" = "805306368000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     # Use tiered storage
     "remote.storage.enable" = "true"
     # keep data in primary storage for 2 days

--- a/prod-aws/kafka-shared-msk/billing/transaction-log.tf
+++ b/prod-aws/kafka-shared-msk/billing/transaction-log.tf
@@ -13,7 +13,7 @@ resource "kafka_topic" "billing_transaction_log_v3" {
     "retention.ms" = "2764800000"
     # making sure cleanup policy is not compaction 
     "cleanup.policy" = "delete"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }

--- a/prod-aws/kafka-shared-msk/contact-channels/contact-channels.tf
+++ b/prod-aws/kafka-shared-msk/contact-channels/contact-channels.tf
@@ -8,7 +8,7 @@ resource "kafka_topic" "genesys_eb_events" {
     "remote.storage.enable" = "true"
     "local.retention.ms"    = "259200000"  # keep data in primary storage for 3 days
     "retention.ms"          = "2629800000" # keep data for 1 month
-    "max.message.bytes"     = "104857600"  # allow for a batch of records maximum 100MiB
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MiB
     "compression.type"      = "zstd"
     "cleanup.policy"        = "delete"
   }
@@ -164,7 +164,7 @@ resource "kafka_topic" "dsar" {
     "remote.storage.enable" = "true"
     "local.retention.ms"    = "259200000"  # keep data in primary storage for 3 days
     "retention.ms"          = "2629800000" # keep data for 1 month
-    "max.message.bytes"     = "104857600"  # allow for a batch of records maximum 100MiB
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MiB
     "compression.type"      = "zstd"
     "cleanup.policy"        = "delete"
   }
@@ -180,7 +180,7 @@ resource "kafka_topic" "dsar_job" {
     "remote.storage.enable" = "true"
     "local.retention.ms"    = "259200000"  # keep data in primary storage for 3 days
     "retention.ms"          = "2629800000" # keep data for 1 month
-    "max.message.bytes"     = "104857600"  # allow for a batch of records maximum 100MiB
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MiB
     "compression.type"      = "zstd"
     "cleanup.policy"        = "delete"
   }
@@ -196,7 +196,7 @@ resource "kafka_topic" "dsar_conversation" {
     "remote.storage.enable" = "true"
     "local.retention.ms"    = "259200000"  # keep data in primary storage for 3 days
     "retention.ms"          = "2629800000" # keep data for 1 month
-    "max.message.bytes"     = "104857600"  # allow for a batch of records maximum 100MiB
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MiB
     "compression.type"      = "zstd"
     "cleanup.policy"        = "delete"
   }
@@ -213,7 +213,7 @@ resource "kafka_topic" "auto_email_drafts" {
     "remote.storage.enable" = "true"
     "local.retention.ms"    = "259200000"  # keep data in primary storage for 3 days
     "retention.ms"          = "2629800000" # keep data for 1 month
-    "max.message.bytes"     = "104857600"  # allow for a batch of records maximum 100MiB
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MiB
     "compression.type"      = "zstd"
     "cleanup.policy"        = "delete"
   }

--- a/prod-aws/kafka-shared-msk/customer-billing/topics.tf
+++ b/prod-aws/kafka-shared-msk/customer-billing/topics.tf
@@ -110,8 +110,8 @@ resource "kafka_topic" "invoice_generator" {
     "local.retention.ms" = "86400000"
     # keep data for 7 days
     "retention.ms" = "604800000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }
@@ -144,8 +144,8 @@ resource "kafka_topic" "bex_invoice_api" {
     "local.retention.ms" = "86400000"
     # keep data for 7 days
     "retention.ms" = "604800000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }
@@ -161,8 +161,8 @@ resource "kafka_topic" "bex_legacy_invoice_api" {
     "local.retention.ms" = "86400000"
     # keep data for 7 days
     "retention.ms" = "604800000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }
@@ -199,8 +199,8 @@ resource "kafka_topic" "transition_bex_fulfilment_request" {
     "local.retention.ms" = "86400000"
     "compression.type"   = "zstd"
     "retention.bytes"    = "8053063680" # keep on each partition 7.5GiB
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "cleanup.policy"    = "delete"
     # keep data for 14 days
     "retention.ms" = "1209600000"

--- a/prod-aws/kafka-shared-msk/iam/iam.tf
+++ b/prod-aws/kafka-shared-msk/iam/iam.tf
@@ -193,8 +193,8 @@ resource "kafka_topic" "iam_identitydb_v1" {
     "retention.ms" = "2592000000"
     # keep data in primary storage for 2 days
     "local.retention.ms" = "172800000"
-    # allow for a batch of records maximum 5MiB
-    "max.message.bytes" = "5242880"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }

--- a/prod-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-full-cluster.tf
+++ b/prod-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-full-cluster.tf
@@ -21,8 +21,8 @@ resource "kafka_topic" "plan_restore_full" {
     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
     # keep data for 3 days
     "retention.ms" = "259200000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }

--- a/prod-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-test.tf
+++ b/prod-aws/kafka-shared-msk/pubsub/msk-data-keep-restore-test.tf
@@ -21,8 +21,8 @@ resource "kafka_topic" "plan_restore_test" {
     "local.retention.ms"    = "86400000" # keep data in primary storage for 1 day
     # keep data for 3 days
     "retention.ms" = "259200000"
-    # allow for a batch of records maximum 100MiB
-    "max.message.bytes" = "104857600"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }
@@ -43,8 +43,8 @@ resource "kafka_topic" "restore_test_topic" {
     "retention.ms" = "2592000000"
     # keep data in primary storage for 2 days
     "local.retention.ms" = "172800000"
-    # allow for a batch of records maximum 5MiB
-    "max.message.bytes" = "5242880"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
     "compression.type"  = "zstd"
     "cleanup.policy"    = "delete"
   }

--- a/prod-aws/kafka-shared-msk/unicom/topics.tf
+++ b/prod-aws/kafka-shared-msk/unicom/topics.tf
@@ -692,8 +692,8 @@ resource "kafka_topic" "unicom_status" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -711,8 +711,8 @@ resource "kafka_topic" "unicom_status_bill_email_connector" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -730,8 +730,8 @@ resource "kafka_topic" "unicom_status_energy_smets1_notifier" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -749,8 +749,8 @@ resource "kafka_topic" "unicom_status_finance_email_delivery_engine" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -768,8 +768,8 @@ resource "kafka_topic" "unicom_status_v2" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -855,8 +855,8 @@ resource "kafka_topic" "unicom_comms_api_requests" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -874,8 +874,8 @@ resource "kafka_topic" "unicom_braze_backfill" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }
 
@@ -893,7 +893,7 @@ resource "kafka_topic" "unicom_di_kafka_source_notification" {
     "remote.storage.enable" = "true"
     # keep data in primary storage for 3 days
     "local.retention.ms" = "259200000"
-    # allow for a batch of records maximum 512MiB
-    "max.message.bytes" = "536870912"
+    # allow for a batch of records maximum 3MiB
+    "max.message.bytes" = "3145728"
   }
 }


### PR DESCRIPTION
The MSK cluster is shared across teams, so a topic allowed to take larger messages lets one producer inflate broker memory, replication traffic, and disk I/O in a way that degrades every other topic on the cluster. Keeping a single, uniform cap is what lets us reason about capacity and avoid one team's traffic pattern causing a noisy-neighbour incident for everyone else.

We are enforcing a hard limit of 3MB across all topics. We checked that so far no apps are producing messages larger than 1MB, so this is a safe ceiling.

This is a companion PR to the dev change, both driven by the precondition documented at https://github.com/utilitywarehouse/documentation/blob/master/tech_stack/kafka/msk-migration.md#precondition